### PR TITLE
Add participation routes

### DIFF
--- a/src/controllers/participation.ts
+++ b/src/controllers/participation.ts
@@ -1,0 +1,123 @@
+import { Participation } from "../models/participation";
+import { Request, Response } from "express";
+import { resFormat, resGetALL, resGetOne } from "../utils/types";
+
+
+/**
+ * get all participation of 1 grandprix
+ */
+export const getParticipationsByGPHandler = async (req: Request, res: Response) => {
+    try {
+        const participationList = await Participation.find({gp_id: req.params.id})
+        if (participationList.length == 0) {
+            const msg: resFormat = {
+                message: "there is no participation of such grand prix",
+            }
+            return res.status(404).json(msg)
+        }
+            
+        const msg: resGetALL = {
+            message: "successfully get all participation of 1 grand prix",
+            list: participationList
+        }
+        
+        return res.status(200).json(msg)
+    }
+    catch(err) {
+        console.log("get participation list error")
+        console.log(err)
+        const msg : resFormat = {message: "get participation list fail"}
+        return res.status(500).json(msg)
+    }
+}
+
+
+
+/**
+ * get all participation of 1 driver in 1 year
+ */
+export const getParticipationsByDriverHandler = async (req: Request, res: Response) => {
+    try {
+        const participationList = await Participation.find({driver_id: req.params.id, year: req.params.year})
+        if (participationList.length == 0) {
+            const msg: resFormat = {
+                message: "there is no participation of such driver in that year",
+            }
+            return res.status(404).json(msg)
+        }
+        
+        const msg: resGetALL = {
+            message: "successfully get all participation of 1 driver in 1 year",
+            list: participationList
+        }
+        
+        return res.status(200).json(msg)
+    }
+    catch(err) {
+        console.log("get participation list error")
+        console.log(err)
+        const msg : resFormat = {message: "get participation list fail"}
+        return res.status(500).json(msg)
+    }
+}
+
+/**
+ * get all participation of 1 team in 1 year
+ */
+export const getParticipationsByTeamHandler = async (req: Request, res: Response) => {
+    try {
+        const participationList = await Participation.find({team_id: req.params.id, year: req.params.year})
+        if (participationList.length == 0) {
+            const msg: resFormat = {
+                message: "there is no participation of such team in that year",
+            }
+            return res.status(404).json(msg)
+        }
+        
+        const msg: resGetALL = {
+            message: "successfully get all participation of 1 team in 1 year",
+            list: participationList
+        }
+        
+        return res.status(200).json(msg)
+    }
+    catch(err) {
+        console.log("get participation list error")
+        console.log(err)
+        const msg : resFormat = {message: "get participation list fail"}
+        return res.status(500).json(msg)
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+/**
+ * get one specific participation by the id
+ */
+
+export const getOneParticipationHandler = async (req: Request, res: Response) => {
+    try {
+        const participation = await Participation.findById(req.params.id)
+        if (!participation) {
+            return res.status(404).json({ message: "participation not found" })
+        }
+        const msg : resGetOne = { message: "successfully get participation", target: participation}
+        return res.status(200).json(msg)    
+    } 
+    catch (err) {
+        console.log("get participation list error")
+        console.log(err)
+        const msg : resFormat = {message: "get participation fail"}
+        return res.status(500).json(msg)
+    }
+}

--- a/src/docs/Participation/getOneParticipation.ts
+++ b/src/docs/Participation/getOneParticipation.ts
@@ -1,0 +1,56 @@
+export default {
+    // method of operation
+    get: {
+        tags: ["participation-operations"], 
+        description: "Get one participation", 
+        operationId: "getOneParticipation", 
+        parameters: [
+            {
+                name: "id", 
+                in: "path", 
+                schema: {
+                  $ref: "#/components/schemas/id", 
+                },
+                required: true, 
+                description: "A single participation id",
+            },
+        ], 
+        // expected responses
+        responses: {
+            200: {
+                description: "Received specified participation successfully", 
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: '#/components/schemas/Participation', 
+                        },
+                    },
+                },
+            },
+            // response code
+            404: {
+                description: "Participation not found", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+            500: {
+                description: "Internal errors", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+        },
+    }
+};

--- a/src/docs/Participation/getParticipationByDriver.ts
+++ b/src/docs/Participation/getParticipationByDriver.ts
@@ -1,0 +1,65 @@
+export default {
+    // method of operation
+    get: {
+        tags: ["participation-operations"], 
+        description: "Get all participation by 1 driver in 1 year", 
+        operationId: "getAllParticipationByGP", 
+        parameters: [
+            {
+                name: "id", 
+                in: "path", 
+                schema: {
+                  $ref: "#/components/schemas/id", 
+                },
+                required: true, 
+                description: "driver id that want to search",
+            },
+            {
+                name: "year", 
+                in: "path", 
+                schema: {
+                  $ref: "#/components/schemas/year", 
+                },
+                required: true, 
+                description: "the year that the driver participated in",
+            },
+        ], 
+        // expected responses
+        responses: {
+            200: {
+                description: "Received all participation successfully", 
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: '#/components/schemas/ParticipationList', 
+                        },
+                    },
+                },
+            },
+            // response code
+            404: {
+                description: "ParticipationList not found", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+            500: {
+                description: "Internal error", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+        },
+    }
+};

--- a/src/docs/Participation/getParticipationByGP.ts
+++ b/src/docs/Participation/getParticipationByGP.ts
@@ -1,0 +1,56 @@
+export default {
+    // method of operation
+    get: {
+        tags: ["participation-operations"], 
+        description: "Get all participation by grandprix", 
+        operationId: "getAllParticipationByGP", 
+        parameters: [
+            {
+                name: "id", 
+                in: "path", 
+                schema: {
+                  $ref: "#/components/schemas/id", 
+                },
+                required: true, 
+                description: "grandprix id that want to search",
+            },
+        ], 
+        // expected responses
+        responses: {
+            200: {
+                description: "Received all participation successfully", 
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: '#/components/schemas/ParticipationList', 
+                        },
+                    },
+                },
+            },
+            // response code
+            404: {
+                description: "ParticipationList not found", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+            500: {
+                description: "Internal error", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+        },
+    }
+};

--- a/src/docs/Participation/getParticipationByTeam.ts
+++ b/src/docs/Participation/getParticipationByTeam.ts
@@ -1,0 +1,65 @@
+export default {
+    // method of operation
+    get: {
+        tags: ["participation-operations"], 
+        description: "Get all participation by 1 team in 1 year", 
+        operationId: "getAllParticipationByGP", 
+        parameters: [
+            {
+                name: "id", 
+                in: "path", 
+                schema: {
+                  $ref: "#/components/schemas/id", 
+                },
+                required: true, 
+                description: "team id that want to search",
+            },
+            {
+                name: "year", 
+                in: "path", 
+                schema: {
+                  $ref: "#/components/schemas/year", 
+                },
+                required: true, 
+                description: "the year that the team participated in",
+            },
+        ], 
+        // expected responses
+        responses: {
+            200: {
+                description: "Received all participation successfully", 
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: '#/components/schemas/ParticipationList', 
+                        },
+                    },
+                },
+            },
+            // response code
+            404: {
+                description: "ParticipationList not found", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+            500: {
+                description: "Internal error", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+        },
+    }
+};

--- a/src/docs/Participation/index.ts
+++ b/src/docs/Participation/index.ts
@@ -1,0 +1,19 @@
+import getOneParticipation from './getOneParticipation';
+import getParticipationByGP from './getParticipationByGP';
+import getParticipationByDriver from './getParticipationByDriver';
+import getParticipationByTeam from './getParticipationByTeam';
+
+export default {
+    '/api/v1/participation/grandprix/{id}': {
+        ...getParticipationByGP,
+    },
+    '/api/v1/participation/driver/{id}/{year}': {
+        ...getParticipationByDriver,
+    },
+    '/api/v1/participation/team/{id}/{year}': {
+        ...getParticipationByTeam,
+    },
+    '/api/v1/participation/{id}': {
+        ...getOneParticipation,
+    },
+}

--- a/src/docs/components.ts
+++ b/src/docs/components.ts
@@ -78,7 +78,7 @@ export default {
             t_name: {
                 type: 'string',
                 example: 'Mercedes'
-            },          
+            },
             Team: {
                 type: "object",
                 properties: {
@@ -91,10 +91,67 @@ export default {
                 },
             },
             TeamList: {
-                type: "array", 
+                type: "array",
                 description: "an array of teams",
                 items: {
                     $ref: '#/components/schemas/Team'
+                },
+            },
+            // Participation model
+            time: {
+                type: "string",
+                example: "1:32:58.710"
+            },
+            laps: {
+                type: "number",
+                example: 57
+            },
+            pos: {
+                type: "string",
+                example: "2"
+            },
+            points: {
+                type: "number",
+                example: 25
+            },
+            Participation: {
+                type: "object",
+                properties: {
+                    _id: {
+                        $ref: '#/components/schemas/id'
+                    },
+                    gp_id: {
+                        $ref: '#/components/schemas/id'
+                    },
+                    driver_id: {
+                        $ref: '#/components/schemas/id'
+                    },
+                    team_id: {
+                        $ref: '#/components/schemas/id'
+                    },
+                    year: {
+                        $ref: '#/components/schemas/year'
+                    },
+                    time: {
+                        $ref: '#/components/schemas/time'
+                    },
+
+                    laps: {
+                        $ref: '#/components/schemas/laps'
+                    },
+                    pos: {
+                        $ref: '#/components/schemas/pos'
+                    },
+                    points: {
+                        $ref: '#/components/schemas/points'
+                    },
+                },
+            },
+            ParticipationList: {
+                type: "array", 
+                description: "an array of participation",
+                items: {
+                    $ref: '#/components/schemas/Participation'
                 },
             },
             // Error model

--- a/src/docs/paths.ts
+++ b/src/docs/paths.ts
@@ -1,11 +1,13 @@
 import Grandprix from './GrandPrix'
 import Drivers from './Drivers'
 import Teams from './Teams'
+import Participation from './Participation'
 
 export default {
     paths: {
         ...Grandprix,
         ...Drivers,
-        ...Teams
+        ...Teams,
+        ...Participation
     }
 }

--- a/src/docs/tags.ts
+++ b/src/docs/tags.ts
@@ -8,6 +8,9 @@ export default {
 		},
 		{
 			name: "team-operations",
+		},
+		{
+			name: "participation-operations",
 		}
 	],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import path from "path";
 import grandprixRoutes from './routes/grandprix';
 import driverRoutes from './routes/driver';
 import teamRoutes from './routes/team'
+import participationRoutes from './routes/participation'
 
 // for auto documentation 
 import swaggerUi from 'swagger-ui-express';
@@ -32,6 +33,7 @@ app.get("/healthcheck", (req: Request, res: Response) => {
 app.use('/api/v1/grandprix', grandprixRoutes)
 app.use('/api/v1/drivers', driverRoutes)
 app.use('/api/v1/teams', teamRoutes)
+app.use('/api/v1/participation', participationRoutes)
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(docs));
 

--- a/src/models/driver.ts
+++ b/src/models/driver.ts
@@ -1,4 +1,5 @@
 import { Schema, model } from 'mongoose';
+import { config } from '../config';
 
 // Create an interface representing a document in MongoDB.
 export interface IDriver {
@@ -9,8 +10,9 @@ export interface IDriver {
 // Create a Schema corresponding to the document interface.
 const driverSchema = new Schema<IDriver>({
     name: { type: String, required: true, index: true },
-    nationality: {type: String, required: true }
-});
+    nationality: { type: String, required: true }
+},
+    { collection: config.db.driversColl });
 
 // Create a Model.
 export const Driver = model<IDriver>('Driver', driverSchema);

--- a/src/models/participation.ts
+++ b/src/models/participation.ts
@@ -1,4 +1,5 @@
 import { Schema, Types, model } from 'mongoose';
+import { config } from '../config';
 
 // Create an interface representing a document in MongoDB.
 export interface IParticipation {
@@ -9,6 +10,7 @@ export interface IParticipation {
     laps: number;
     pos: string;
     points: number;
+    year: number;
 }
 
 // Create a Schema corresponding to the document interface.
@@ -28,8 +30,10 @@ const participationSchema = new Schema<IParticipation>({
     time: { type: String, required: true },
     laps: { type: Number, required: true },
     pos: { type: String, required: true },
-    points: { type: Number, required: true }
-});
+    points: { type: Number, required: true },
+    year: { type: Number, required: true }
+},
+    { collection: config.db.participationColl });
 
 // Create a Model.
 export const Participation = model<IParticipation>('Participation', participationSchema);

--- a/src/models/team.ts
+++ b/src/models/team.ts
@@ -1,4 +1,5 @@
 import { Schema, model } from 'mongoose';
+import { config } from '../config';
 
 // Create an interface representing a document in MongoDB.
 export interface ITeam {
@@ -8,7 +9,8 @@ export interface ITeam {
 // Create a Schema corresponding to the document interface.
 const teamSchema = new Schema<ITeam>({
     t_name: { type: String, required: true, index: true },
-});
+},
+    { collection: config.db.teamsColl });
 
 // Create a Model.
 export const Team = model<ITeam>('Team', teamSchema);

--- a/src/routes/participation.ts
+++ b/src/routes/participation.ts
@@ -1,0 +1,17 @@
+import { Router } from "express"
+import {
+    getParticipationsByGPHandler,
+    getParticipationsByDriverHandler,
+    getParticipationsByTeamHandler,
+    getOneParticipationHandler
+} from "../controllers/participation"
+
+const router = Router()
+
+// CRUD 
+router.get("/grandprix/:id", getParticipationsByGPHandler)
+router.get("/driver/:id/:year", getParticipationsByDriverHandler)
+router.get("/team/:id/:year", getParticipationsByTeamHandler)
+router.get("/:id", getOneParticipationHandler)
+
+export default router

--- a/src/test/test_participation.ts
+++ b/src/test/test_participation.ts
@@ -1,0 +1,126 @@
+import { assert } from 'chai';
+import requestInstance from './client';
+
+describe('Participation API', () => {
+    describe('GET /participation/grandprix/:id', () => {
+        it('should return all participation of 1 grandprix', async () => {
+            const grandprixId = '649d3c55e81209641c7096c4'
+            const response = await requestInstance.get(`/participation/grandprix/${grandprixId}`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+        });
+        it('should return 404 if participation of invalid grand prix', async () => {
+            try {
+                const nonExistentId = '649d794f987b834ba97b0f8a'; // Replace with a non-existent participation id
+                await requestInstance.get(`/participation/grandprix/${nonExistentId}`);
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'there is no participation of such grand prix');
+                return
+            }
+            throw `Should throw error but did not`
+        });
+    });
+
+
+
+    describe('GET /participation/driver/:id/:year', () => {
+        it('should return all participation of 1 driver in 1 year', async () => {
+            const driverId = '649d4ddb61c89321f5d7ebd5'
+            const year = 2014
+            const response = await requestInstance.get(`/participation/driver/${driverId}/${year}`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+        });
+        it('should return 404 if participation of invalid driver id with valid year', async () => {
+            try {
+                const nonExistentId = '649d794f987b834ba97b0f8a'; // Replace with a non-existent participation id
+                await requestInstance.get(`/participation/driver/${nonExistentId}/2014`);
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'there is no participation of such driver in that year');
+                return
+            }
+            throw `Should throw error but did not`
+        });
+
+        it('should return 404 if participation of invalid year with valid driver id', async () => {
+            try {
+                const driverId = '649d4ddb61c89321f5d7ebd5'; // Replace with a non-existent participation id
+                await requestInstance.get(`/participation/driver/${driverId}/2011`);
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'there is no participation of such driver in that year');
+                return
+            }
+            throw `Should throw error but did not`
+        });
+    });
+
+
+
+    describe('GET /participation/team/:id/:year', () => {
+        it('should return all participation of 1 team in 1 year', async () => {
+            const teamId = '649d42fb8f9d812c3201f569'
+            const year = 2014
+            const response = await requestInstance.get(`/participation/team/${teamId}/${year}`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+        });
+        it('should return 404 if participation of invalid team id with valid year', async () => {
+            try {
+                const nonExistentId = '649d794f987b834ba97b0f8a'; // Replace with a non-existent participation id
+                await requestInstance.get(`/participation/team/${nonExistentId}/2014`);
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'there is no participation of such team in that year');
+                return
+            }
+            throw `Should throw error but did not`
+        });
+
+        it('should return 404 if participation of invalid year with valid team id', async () => {
+            try {
+                const teamId = '649d4ddb61c89321f5d7ebd5'; // Replace with a non-existent participation id
+                await requestInstance.get(`/participation/team/${teamId}/2011`);
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'there is no participation of such team in that year');
+                return
+            }
+            throw `Should throw error but did not`
+        });
+    });
+
+
+
+    describe('GET /participation/:id', () => {
+        it('should return a specific participation', async () => {
+            const grandPrixId = '649d794f987b834ba97b0f8a';
+            const response = await requestInstance.get(`/participation/${grandPrixId}`);
+            assert.strictEqual(response.status, 200);
+            assert.strictEqual(response.data.target._id, grandPrixId);
+        });
+
+        it('should return 404 if participation not found', async () => {
+            try {
+                const nonExistentId = '649d3c55e81209641c7096c3'; // Replace with a non-existent participation id
+                await requestInstance.get(`/participation/${nonExistentId}`);
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'participation not found');
+                return
+            }
+            throw `Should throw error but did not`
+        });
+    });
+});


### PR DESCRIPTION
## Done:
- Add routes for Participation 
    - `GET` 1 participation by its id 
    - `GET` all participation of 1 granprix 
    - `GET` all participation of 1 driver in 1 year
    - `GET` all participation of 1 team in 1 year 
- Add auto documention for Participation 
- Add unittest for Participation

## Auto docs result 
![image](https://github.com/tten5/F1ResultsApp/assets/71060912/b049e496-29ea-4234-97f3-d896b6a3ec43)

## Unittest result
![image](https://github.com/tten5/F1ResultsApp/assets/71060912/a809ff88-b4c7-4f3a-9a53-ee086d8827f0)
