### PR TITLE
Add get by year

### DIFF
--- a/src/controllers/driver.ts
+++ b/src/controllers/driver.ts
@@ -1,26 +1,31 @@
-import { Driver } from "../models/driver";
+import { Driver, IDriver } from "../models/driver";
 import { Participation } from "../models/participation";
 import { Request, Response } from "express";
 import { resFormat, resGetALL, resGetOne } from "../utils/types";
 
 
 /**
- * get all drivers
+ * get all drivers and return in alphabetical order
  */
 export const getDriversHandler = async (req: Request, res: Response) => {
     try {
-        const driverList = await Driver.find({})
+        let driverList: IDriver[]
+        if (req.query.sort === 'firstname') {
+            driverList = await Driver.find({}).sort({ firstname: 1 })
+        } else {
+            driverList = await Driver.find({}).sort({ lastname: 1 })
+        }
         const msg: resGetALL = {
             message: "successfully get all drivers",
             list: driverList
         }
-        
+
         return res.status(200).json(msg)
     }
-    catch(err) {
+    catch (err) {
         console.log("get drivers list error")
         console.log(err)
-        const msg : resFormat = {message: "get drivers list fail"}
+        const msg: resFormat = { message: "get drivers list fail" }
         return res.status(500).json(msg)
     }
 }
@@ -35,19 +40,19 @@ export const getOneDriverHandler = async (req: Request, res: Response) => {
         if (!driver) {
             return res.status(404).json({ message: "driver not found" })
         }
-        const msg : resGetOne = { message: "successfully get driver", target: driver}
-        return res.status(200).json(msg)    
-    } 
+        const msg: resGetOne = { message: "successfully get driver", target: driver }
+        return res.status(200).json(msg)
+    }
     catch (err) {
         console.log("get driver list error")
         console.log(err)
-        const msg : resFormat = {message: "get driver fail"}
+        const msg: resFormat = { message: "get driver fail" }
         return res.status(500).json(msg)
     }
 }
 
 /**
- * get all driver in 1 year
+ * get all driver in 1 year and return in alphabet order
  */
 export const getDriversByYearHandler = async (req: Request, res: Response) => {
     try {
@@ -60,25 +65,31 @@ export const getDriversByYearHandler = async (req: Request, res: Response) => {
             return res.status(404).json(msg)
         }
 
-        const driverList = await Driver.find({ _id: { $in: driverIdList }})        
+        let driverList: IDriver[]
+        if (req.query.sort === 'firstname') {
+            driverList = await Driver.find({ _id: { $in: driverIdList } }).sort({ firstname: 1 })
+        } else {
+            driverList = await Driver.find({ _id: { $in: driverIdList } }).sort({ lastname: 1 })
+        }
+
         if (driverList.length == 0) {
             const msg: resFormat = {
                 message: "there is no driver in that year",
             }
             return res.status(404).json(msg)
         }
-        
+
         const msg: resGetALL = {
             message: "successfully get all drivers in 1 year",
             list: driverList
         }
-        
+
         return res.status(200).json(msg)
     }
-    catch(err) {
+    catch (err) {
         console.log("get driver list in 1 year error")
         console.log(err)
-        const msg : resFormat = {message: "get drivers in 1 year fail"}
+        const msg: resFormat = { message: "get drivers in 1 year fail" }
         return res.status(500).json(msg)
     }
 }

--- a/src/controllers/driver.ts
+++ b/src/controllers/driver.ts
@@ -1,4 +1,5 @@
 import { Driver } from "../models/driver";
+import { Participation } from "../models/participation";
 import { Request, Response } from "express";
 import { resFormat, resGetALL, resGetOne } from "../utils/types";
 
@@ -41,6 +42,43 @@ export const getOneDriverHandler = async (req: Request, res: Response) => {
         console.log("get driver list error")
         console.log(err)
         const msg : resFormat = {message: "get driver fail"}
+        return res.status(500).json(msg)
+    }
+}
+
+/**
+ * get all driver in 1 year
+ */
+export const getDriversByYearHandler = async (req: Request, res: Response) => {
+    try {
+        // unique driverIds of 1 year
+        const driverIdList = await Participation.find({ year: Number(req.params.year) }).distinct("driver_id")
+        if (driverIdList.length == 0) {
+            const msg: resFormat = {
+                message: "there is no driver in that year",
+            }
+            return res.status(404).json(msg)
+        }
+
+        const driverList = await Driver.find({ _id: { $in: driverIdList }})        
+        if (driverList.length == 0) {
+            const msg: resFormat = {
+                message: "there is no driver in that year",
+            }
+            return res.status(404).json(msg)
+        }
+        
+        const msg: resGetALL = {
+            message: "successfully get all drivers in 1 year",
+            list: driverList
+        }
+        
+        return res.status(200).json(msg)
+    }
+    catch(err) {
+        console.log("get driver list in 1 year error")
+        console.log(err)
+        const msg : resFormat = {message: "get drivers in 1 year fail"}
         return res.status(500).json(msg)
     }
 }

--- a/src/controllers/driver.ts
+++ b/src/controllers/driver.ts
@@ -2,7 +2,7 @@ import { Driver, IDriver } from "../models/driver";
 import { Participation } from "../models/participation";
 import { Request, Response } from "express";
 import { resFormat, resGetALL, resGetOne } from "../utils/types";
-
+import { config } from "../config";
 
 /**
  * get all drivers and return in alphabetical order
@@ -52,7 +52,7 @@ export const getOneDriverHandler = async (req: Request, res: Response) => {
 }
 
 /**
- * get all driver in 1 year and return in alphabet order
+ * get all driver in 1 year and return in order
  */
 export const getDriversByYearHandler = async (req: Request, res: Response) => {
     try {
@@ -90,6 +90,101 @@ export const getDriversByYearHandler = async (req: Request, res: Response) => {
         console.log("get driver list in 1 year error")
         console.log(err)
         const msg: resFormat = { message: "get drivers in 1 year fail" }
+        return res.status(500).json(msg)
+    }
+}
+
+/**
+ * get sum points of all driver in 1 year 
+ */
+export const getSumPtsAllDriversHandler = async (req: Request, res: Response) => {
+    try {
+
+        const year = Number(req.params.year)
+        const sumPts = await Participation.aggregate([
+            {
+                $match: {
+                    year: year
+                }
+            },
+            {
+                $group: {
+                    _id: '$driver_id',
+                    sumPoints: { $sum: '$real_pts' },
+                    team_id: {
+                        $addToSet: {
+                            team_id: '$team_id'
+                        }
+                    } // to find team
+                }
+            },
+            {
+                $lookup: {
+                    from: config.db.driversColl,
+                    localField: '_id',
+                    foreignField: '_id',
+                    as: 'driver'
+                }
+            },
+            {
+                $lookup: {
+                    from: config.db.teamsColl,
+                    localField: 'team_id.team_id',
+                    foreignField: '_id',
+                    as: 'team'
+                }
+            },
+            {
+                $setWindowFields: {
+                    partitionBy: "$state",
+                    sortBy: { sumPoints: -1 },
+                    output: {
+                        rankOrder: {
+                            $rank: {}
+                        }
+                    }
+                }
+            },
+        ])
+        if (sumPts.length == 0) {
+            const msg: resFormat = {
+                message: "no drivers points to be found",
+            }
+            return res.status(404).json(msg)
+        }
+
+        // Add percentage field to output
+        let totalSumPts = 0.0
+        for (let i = 0; i < sumPts.length; i++) {
+            totalSumPts += sumPts[i].sumPoints
+        }
+        let sumPtsOutput = []
+        for (let i = 0; i < sumPts.length; i++) {
+            const driverFirstname = sumPts[i].driver[0].firstname
+            const driverLastname = sumPts[i].driver[0].lastname
+
+            sumPtsOutput.push({
+                driver_id: sumPts[i].driver[0]._id,
+                pos: sumPts[i].rankOrder,
+                driver: `${driverFirstname} ${driverLastname}`,
+                nationality: sumPts[i].driver[0].nationality,
+                team: sumPts[i].team[0].t_name,
+                sumPts: sumPts[i].sumPoints,
+                percentage: ((sumPts[i].sumPoints / totalSumPts) * 100).toFixed(2) // to 2 decimal places
+            })
+        }
+
+        const msg: resGetALL = {
+            message: "successfully get all drivers' sum points",
+            list: sumPtsOutput
+        }
+
+        return res.status(200).json(msg)
+    }
+    catch (err) {
+        console.log("get all drivers' sum points error")
+        console.log(err)
+        const msg: resFormat = { message: "get all drivers' sum points fail" }
         return res.status(500).json(msg)
     }
 }

--- a/src/controllers/grandprix.ts
+++ b/src/controllers/grandprix.ts
@@ -43,3 +43,31 @@ export const getOneGPHandler = async (req: Request, res: Response) => {
         return res.status(500).json(msg)
     }
 }
+
+/**
+ * get all grandprix in 1 year
+ */
+export const getGPByYearHandler = async (req: Request, res: Response) => {
+    try {
+        const grandprixList = await GrandPrix.find({year: req.params.year})
+        if (grandprixList.length == 0) {
+            const msg: resFormat = {
+                message: "there is no grandprix in that year",
+            }
+            return res.status(404).json(msg)
+        }
+        
+        const msg: resGetALL = {
+            message: "successfully get all grandprix in 1 year",
+            list: grandprixList
+        }
+        
+        return res.status(200).json(msg)
+    }
+    catch(err) {
+        console.log("get grandprix list in 1 year error")
+        console.log(err)
+        const msg : resFormat = {message: "get grandprix in 1 year fail"}
+        return res.status(500).json(msg)
+    }
+}

--- a/src/controllers/grandprix.ts
+++ b/src/controllers/grandprix.ts
@@ -1,24 +1,24 @@
-import { GrandPrix } from "../models/grandprix";
+import { GrandPrix, IGrandPrix } from "../models/grandprix";
 import { Request, Response } from "express";
 import { resFormat, resGetALL, resGetOne } from "../utils/types";
 
 /**
- * get all grandprix
+ * get all grandprix and return grandprix list in place order
  */
 export const getAllGPHandler = async (req: Request, res: Response) => {
     try {
-        const grandprixList = await GrandPrix.find({})
+        const grandprixList = await GrandPrix.find({}).sort({place: 1})
         const msg: resGetALL = {
             message: "successfully get all grandprix",
             list: grandprixList
         }
-        
+
         return res.status(200).json(msg)
     }
-    catch(err) {
+    catch (err) {
         console.log("get grandprix list error")
         console.log(err)
-        const msg : resFormat = {message: "get grandprix list fail"}
+        const msg: resFormat = { message: "get grandprix list fail" }
         return res.status(500).json(msg)
     }
 }
@@ -33,41 +33,48 @@ export const getOneGPHandler = async (req: Request, res: Response) => {
         if (!grandprix) {
             return res.status(404).json({ message: "grandprix not found" })
         }
-        const msg : resGetOne = { message: "successfully get grandprix", target: grandprix}
-        return res.status(200).json(msg)    
-    } 
+        const msg: resGetOne = { message: "successfully get grandprix", target: grandprix }
+        return res.status(200).json(msg)
+    }
     catch (err) {
         console.log("get grandprix list error")
         console.log(err)
-        const msg : resFormat = {message: "get grandprix fail"}
+        const msg: resFormat = { message: "get grandprix fail" }
         return res.status(500).json(msg)
     }
 }
 
 /**
- * get all grandprix in 1 year
+ * get all grandprix in 1 year and return by sort query
  */
 export const getGPByYearHandler = async (req: Request, res: Response) => {
     try {
-        const grandprixList = await GrandPrix.find({year: req.params.year})
+        const year = Number(req.params.year)
+        let grandprixList: IGrandPrix[]
+        if (req.query.sort === 'place') {
+            grandprixList = await GrandPrix.find({ year: year }).sort({ place: 1 })
+        } else { 
+            // default is sort by date
+            grandprixList = await GrandPrix.find({ year: year })
+        }
         if (grandprixList.length == 0) {
             const msg: resFormat = {
                 message: "there is no grandprix in that year",
             }
             return res.status(404).json(msg)
         }
-        
+
         const msg: resGetALL = {
             message: "successfully get all grandprix in 1 year",
             list: grandprixList
         }
-        
+
         return res.status(200).json(msg)
     }
-    catch(err) {
+    catch (err) {
         console.log("get grandprix list in 1 year error")
         console.log(err)
-        const msg : resFormat = {message: "get grandprix in 1 year fail"}
+        const msg: resFormat = { message: "get grandprix in 1 year fail" }
         return res.status(500).json(msg)
     }
 }

--- a/src/controllers/grandprix.ts
+++ b/src/controllers/grandprix.ts
@@ -1,13 +1,15 @@
 import { GrandPrix, IGrandPrix } from "../models/grandprix";
 import { Request, Response } from "express";
 import { resFormat, resGetALL, resGetOne } from "../utils/types";
+import { Participation } from "../models/participation";
+import { config } from "../config";
 
 /**
  * get all grandprix and return grandprix list in place order
  */
 export const getAllGPHandler = async (req: Request, res: Response) => {
     try {
-        const grandprixList = await GrandPrix.find({}).sort({place: 1})
+        const grandprixList = await GrandPrix.find({}).sort({ place: 1 })
         const msg: resGetALL = {
             message: "successfully get all grandprix",
             list: grandprixList
@@ -53,7 +55,7 @@ export const getGPByYearHandler = async (req: Request, res: Response) => {
         let grandprixList: IGrandPrix[]
         if (req.query.sort === 'place') {
             grandprixList = await GrandPrix.find({ year: year }).sort({ place: 1 })
-        } else { 
+        } else {
             // default is sort by date
             grandprixList = await GrandPrix.find({ year: year })
         }
@@ -75,6 +77,90 @@ export const getGPByYearHandler = async (req: Request, res: Response) => {
         console.log("get grandprix list in 1 year error")
         console.log(err)
         const msg: resFormat = { message: "get grandprix in 1 year fail" }
+        return res.status(500).json(msg)
+    }
+}
+
+
+/**
+ * get all winners (and top 3) of all grandprix in 1 year 
+ */
+export const getWinnersAllGPHandler = async (req: Request, res: Response) => {
+    try {
+        const targetPos = (req.query.top3 == 'true') ? { $in: ["1", "2", "3"] } : "1"
+
+        const year = Number(req.params.year)
+        const winners = await Participation.aggregate([
+            {
+                $match: {
+                    pos: targetPos,
+                    year: year
+                }
+            },
+            {
+                $lookup: {
+                    from: config.db.grandprixColl,
+                    localField: 'gp_id',
+                    foreignField: '_id',
+                    as: 'grandprix'
+                }
+            },
+            {
+                $lookup: {
+                    from: config.db.driversColl,
+                    localField: 'driver_id',
+                    foreignField: '_id',
+                    as: 'driver'
+                }
+            },
+            {
+                $lookup: {
+                    from: config.db.teamsColl,
+                    localField: 'team_id',
+                    foreignField: '_id',
+                    as: 'team'
+                }
+            },
+            {
+                $sort: {
+                    'grandprix.date': 1,
+                },
+            }
+        ])
+        // for format date
+        const options = { day: '2-digit', month: 'short', year: 'numeric' };
+
+        let winnersOutput = []
+        for (let i = 0; i < winners.length; i++) {
+            const winnerFirstname = winners[i].driver[0].firstname
+            const winnerLastname = winners[i].driver[0].lastname
+            const formattedDate = winners[i].grandprix[0].date.
+                toLocaleDateString('en-US', options).replace(',', '');;
+
+            winnersOutput.push({
+                gp_id: winners[i].grandprix[0]._id,
+                grandprix: winners[i].grandprix[0].place,
+                date: formattedDate,
+                pos: winners[i].pos,
+                winner: `${winnerFirstname} ${winnerLastname}`,
+                team: winners[i].team[0].t_name,
+                laps: winners[i].laps,
+                time: winners[i].time
+            })
+
+        }
+
+        const msg: resGetALL = {
+            message: "successfully get all grandprix's winners",
+            list: winnersOutput
+        }
+
+        return res.status(200).json(msg)
+    }
+    catch (err) {
+        console.log("get grandprix's winners list error")
+        console.log(err)
+        const msg: resFormat = { message: "get grandprix's winners list fail" }
         return res.status(500).json(msg)
     }
 }

--- a/src/controllers/participation.ts
+++ b/src/controllers/participation.ts
@@ -1,7 +1,9 @@
 import { Participation } from "../models/participation";
+import { Driver } from "../models/driver";
 import { Request, Response } from "express";
-import { resFormat, resGetALL, resGetOne } from "../utils/types";
-
+import { resFormat, resGetALL, resGetAllOfOne, resGetOne } from "../utils/types";
+import { config } from "../config";
+import { Types } from "mongoose"
 
 /**
  * get all participation of 1 grandprix
@@ -34,11 +36,48 @@ export const getParticipationsByGPHandler = async (req: Request, res: Response) 
 
 
 /**
- * get all participation of 1 driver in 1 year
+ * get all participation of 1 driver in 1 year  
  */
 export const getParticipationsByDriverHandler = async (req: Request, res: Response) => {
     try {
-        const participationList = await Participation.find({driver_id: req.params.id, year: req.params.year})
+        const driver = await Driver.findById(req.params.id)
+        if (!driver) {
+            const msg: resFormat = {
+                message: "there is no participation of such driver in that year",
+            }
+            return res.status(404).json(msg)
+        }
+        const participationList = await Participation.aggregate([
+            {
+                $match: {
+                    driver_id: new Types.ObjectId(req.params.id),
+                    year: Number(req.params.year) 
+                }
+            },
+            {
+                $lookup: {
+                    from: config.db.grandprixColl,
+                    localField: 'gp_id',
+                    foreignField: '_id',
+                    as: 'grandprix'
+                }
+            },
+            {
+                $lookup: {
+                    from: config.db.teamsColl,
+                    localField: 'team_id',
+                    foreignField: '_id',
+                    as: 'team'
+                }
+            },
+            {
+                $sort: {
+                    'grandprix.date': 1,
+                },
+            }
+        ])
+        
+        
         if (participationList.length == 0) {
             const msg: resFormat = {
                 message: "there is no participation of such driver in that year",
@@ -46,9 +85,30 @@ export const getParticipationsByDriverHandler = async (req: Request, res: Respon
             return res.status(404).json(msg)
         }
         
-        const msg: resGetALL = {
+        let participationOutput = []
+        let accumPts = 0.0 
+        const formatOptions = { day: '2-digit', month: 'short', year: 'numeric' };
+        
+        for (let i = 0; i < participationList.length; i++) {
+           
+            const formattedDate = participationList[i].grandprix[0].date.
+                                    toLocaleDateString('en-US', formatOptions).replace(',', '');;
+            accumPts += participationList[i].real_pts
+            participationOutput.push({
+                grandprix: participationList[i].grandprix[0].place,
+                date: formattedDate,
+                team: participationList[i].team[0].t_name,
+                pos: participationList[i].pos,
+                points: participationList[i].real_pts,
+                accumPts: accumPts
+            })
+        }
+
+
+        const msg: resGetAllOfOne = {
             message: "successfully get all participation of 1 driver in 1 year",
-            list: participationList
+            target: driver,
+            list: participationOutput
         }
         
         return res.status(200).json(msg)

--- a/src/controllers/participation.ts
+++ b/src/controllers/participation.ts
@@ -1,7 +1,15 @@
 import { Participation } from "../models/participation";
 import { Driver } from "../models/driver";
+import { Team } from "../models/team";
 import { Request, Response } from "express";
-import { resFormat, resGetALL, resGetAllOfOne, resGetOne } from "../utils/types";
+import {
+    resFormat,
+    resGetALL,
+    resGetAllOfOne,
+    resGetOne,
+    resGetAllOfOneTeam,
+    driverContri
+} from "../utils/types";
 import { config } from "../config";
 import { Types } from "mongoose"
 
@@ -10,25 +18,25 @@ import { Types } from "mongoose"
  */
 export const getParticipationsByGPHandler = async (req: Request, res: Response) => {
     try {
-        const participationList = await Participation.find({gp_id: req.params.id})
+        const participationList = await Participation.find({ gp_id: req.params.id })
         if (participationList.length == 0) {
             const msg: resFormat = {
                 message: "there is no participation of such grand prix",
             }
             return res.status(404).json(msg)
         }
-            
+
         const msg: resGetALL = {
             message: "successfully get all participation of 1 grand prix",
             list: participationList
         }
-        
+
         return res.status(200).json(msg)
     }
-    catch(err) {
+    catch (err) {
         console.log("get participation list error")
         console.log(err)
-        const msg : resFormat = {message: "get participation list fail"}
+        const msg: resFormat = { message: "get participation list fail" }
         return res.status(500).json(msg)
     }
 }
@@ -51,7 +59,7 @@ export const getParticipationsByDriverHandler = async (req: Request, res: Respon
             {
                 $match: {
                     driver_id: new Types.ObjectId(req.params.id),
-                    year: Number(req.params.year) 
+                    year: Number(req.params.year)
                 }
             },
             {
@@ -76,23 +84,23 @@ export const getParticipationsByDriverHandler = async (req: Request, res: Respon
                 },
             }
         ])
-        
-        
+
+
         if (participationList.length == 0) {
             const msg: resFormat = {
                 message: "there is no participation of such driver in that year",
             }
             return res.status(404).json(msg)
         }
-        
+
         let participationOutput = []
-        let accumPts = 0.0 
+        let accumPts = 0.0
         const formatOptions = { day: '2-digit', month: 'short', year: 'numeric' };
-        
+
         for (let i = 0; i < participationList.length; i++) {
-           
+
             const formattedDate = participationList[i].grandprix[0].date.
-                                    toLocaleDateString('en-US', formatOptions).replace(',', '');;
+                toLocaleDateString('en-US', formatOptions).replace(',', '');
             accumPts += participationList[i].real_pts
             participationOutput.push({
                 grandprix: participationList[i].grandprix[0].place,
@@ -110,13 +118,13 @@ export const getParticipationsByDriverHandler = async (req: Request, res: Respon
             target: driver,
             list: participationOutput
         }
-        
+
         return res.status(200).json(msg)
     }
-    catch(err) {
+    catch (err) {
         console.log("get participation list error")
         console.log(err)
-        const msg : resFormat = {message: "get participation list fail"}
+        const msg: resFormat = { message: "get participation list fail" }
         return res.status(500).json(msg)
     }
 }
@@ -126,40 +134,140 @@ export const getParticipationsByDriverHandler = async (req: Request, res: Respon
  */
 export const getParticipationsByTeamHandler = async (req: Request, res: Response) => {
     try {
-        const participationList = await Participation.find({team_id: req.params.id, year: req.params.year})
+        const team = await Team.findById(req.params.id)
+        if (!team) {
+            const msg: resFormat = {
+                message: "there is no participation of such team in that year",
+            }
+            return res.status(404).json(msg)
+        }
+        const participationList = await Participation.aggregate([
+            {
+                $match: {
+                    team_id: new Types.ObjectId(req.params.id),
+                    year: Number(req.params.year)
+                }
+            },
+            {
+                $group: {
+                    _id: '$gp_id',
+                    sumPoints: { $sum: '$real_pts' },
+                    driver_id: {
+                        $push: '$driver_id'
+                    },
+                    participation: { $push: '$$ROOT' }
+                }
+            },
+            {
+                $lookup: {
+                    from: config.db.grandprixColl,
+                    localField: '_id',
+                    foreignField: '_id',
+                    as: 'grandprix'
+                }
+            },
+            {
+                $lookup: {
+                    from: config.db.driversColl,
+                    localField: 'driver_id',
+                    foreignField: '_id',
+                    as: 'driver'
+                }
+            },
+            {
+                $sort: {
+                    'grandprix.date': 1,
+                },
+            }
+        ])
+        const driverPts = await Participation.aggregate([
+            {
+                $match: {
+                    team_id: new Types.ObjectId(req.params.id),
+                    year: Number(req.params.year)
+                }
+            },
+            {
+                $group: {
+                    _id: '$driver_id',
+                    sumPoints: { $sum: '$real_pts' },
+                }
+            },
+            {
+                $lookup: {
+                    from: config.db.driversColl,
+                    localField: '_id',
+                    foreignField: '_id',
+                    as: 'driver'
+                }
+            },
+            {
+                $sort: {
+                    'sumPoints': 1,
+                },
+            }
+        ])
+
+
         if (participationList.length == 0) {
             const msg: resFormat = {
                 message: "there is no participation of such team in that year",
             }
             return res.status(404).json(msg)
         }
-        
-        const msg: resGetALL = {
-            message: "successfully get all participation of 1 team in 1 year",
-            list: participationList
+
+        let participationOutput = []
+        let accumPts = 0.0
+        const formatOptions = { day: '2-digit', month: 'short', year: 'numeric' };
+
+        for (let i = 0; i < participationList.length; i++) {
+
+            const formattedDate = participationList[i].grandprix[0].date.
+                toLocaleDateString('en-US', formatOptions).replace(',', '');
+            accumPts += participationList[i].sumPoints
+            let driverInfos: driverContri[] = []
+            for (let j = 0; j < participationList[i].participation.length; j++) {
+                driverInfos.push({
+                    fullname: `${participationList[i].driver[j].firstname} ${participationList[i].driver[j].lastname}`,
+                    pos: participationList[i].participation[j].pos,
+                    points: participationList[i].participation[j].points
+                })
+            }
+
+            participationOutput.push({
+                grandprix: participationList[i].grandprix[0].place,
+                date: formattedDate,
+                sumPts: participationList[i].sumPoints,
+                accumPts: accumPts,
+                driverInfos: driverInfos
+            })
         }
         
+        let driverPtsOutput = []
+        for (let i = 0; i < driverPts.length; i++) {
+            driverPtsOutput.push({
+                ...driverPts[i],
+                percentage: ((driverPts[i].sumPoints / accumPts) * 100).toFixed(2)
+            })
+        } 
+
+        const msg: resGetAllOfOneTeam = {
+            message: "successfully get all participation of 1 team in 1 year",
+            target: team,
+            list: participationOutput,
+            driverPts: driverPtsOutput
+        }
+
         return res.status(200).json(msg)
+
     }
-    catch(err) {
+    catch (err) {
         console.log("get participation list error")
         console.log(err)
-        const msg : resFormat = {message: "get participation list fail"}
+        const msg: resFormat = { message: "get participation list fail" }
         return res.status(500).json(msg)
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
 
 /**
  * get one specific participation by the id
@@ -171,13 +279,13 @@ export const getOneParticipationHandler = async (req: Request, res: Response) =>
         if (!participation) {
             return res.status(404).json({ message: "participation not found" })
         }
-        const msg : resGetOne = { message: "successfully get participation", target: participation}
-        return res.status(200).json(msg)    
-    } 
+        const msg: resGetOne = { message: "successfully get participation", target: participation }
+        return res.status(200).json(msg)
+    }
     catch (err) {
         console.log("get participation list error")
         console.log(err)
-        const msg : resFormat = {message: "get participation fail"}
+        const msg: resFormat = { message: "get participation fail" }
         return res.status(500).json(msg)
     }
 }

--- a/src/controllers/team.ts
+++ b/src/controllers/team.ts
@@ -1,4 +1,5 @@
 import { Team } from "../models/team";
+import { Participation } from "../models/participation";
 import { Request, Response } from "express";
 import { resFormat, resGetALL, resGetOne } from "../utils/types";
 
@@ -45,24 +46,40 @@ export const getOneTeamHandler = async (req: Request, res: Response) => {
     }
 }
 
-/**
- * get one specific team by the name
- */
 
-export const getTeamByNameHandler = async (req: Request, res: Response) => {
+/**
+ * get all team in 1 year
+ */
+export const getTeamsByYearHandler = async (req: Request, res: Response) => {
     try {
-        const t_name = req.body.teamName
-        const team = await Team.findOne({ t_name : t_name})
-        if (!team) {
-            return res.status(404).json({ message: "team not found" })
+        // unique teamIds of 1 year
+        const teamIdList = await Participation.find({ year: Number(req.params.year) }).distinct("team_id")
+        if (teamIdList.length == 0) {
+            const msg: resFormat = {
+                message: "there is no team in that year",
+            }
+            return res.status(404).json(msg)
         }
-        const msg : resGetOne = { message: "successfully get team", target: team}
-        return res.status(200).json(msg)    
-    } 
-    catch (err) {
-        console.log("get team list error")
+
+        const teamList = await Team.find({ _id: { $in: teamIdList }})        
+        if (teamList.length == 0) {
+            const msg: resFormat = {
+                message: "there is no team in that year",
+            }
+            return res.status(404).json(msg)
+        }
+        
+        const msg: resGetALL = {
+            message: "successfully get all teams in 1 year",
+            list: teamList
+        }
+        
+        return res.status(200).json(msg)
+    }
+    catch(err) {
+        console.log("get team list in 1 year error")
         console.log(err)
-        const msg : resFormat = {message: "get team fail"}
+        const msg : resFormat = {message: "get teams in 1 year fail"}
         return res.status(500).json(msg)
     }
 }

--- a/src/controllers/team.ts
+++ b/src/controllers/team.ts
@@ -48,7 +48,7 @@ export const getOneTeamHandler = async (req: Request, res: Response) => {
 
 
 /**
- * get all team in 1 year
+ * get all team in 1 year and return in alphabet order
  */
 export const getTeamsByYearHandler = async (req: Request, res: Response) => {
     try {
@@ -61,7 +61,7 @@ export const getTeamsByYearHandler = async (req: Request, res: Response) => {
             return res.status(404).json(msg)
         }
 
-        const teamList = await Team.find({ _id: { $in: teamIdList }})        
+        const teamList = await Team.find({ _id: { $in: teamIdList }}).sort({t_name: 1})        
         if (teamList.length == 0) {
             const msg: resFormat = {
                 message: "there is no team in that year",

--- a/src/controllers/team.ts
+++ b/src/controllers/team.ts
@@ -2,7 +2,7 @@ import { Team } from "../models/team";
 import { Participation } from "../models/participation";
 import { Request, Response } from "express";
 import { resFormat, resGetALL, resGetOne } from "../utils/types";
-
+import { config } from "../config";
 
 /**
  * get all teams
@@ -80,6 +80,85 @@ export const getTeamsByYearHandler = async (req: Request, res: Response) => {
         console.log("get team list in 1 year error")
         console.log(err)
         const msg : resFormat = {message: "get teams in 1 year fail"}
+        return res.status(500).json(msg)
+    }
+}
+
+/**
+ * get sum points of all team in 1 year 
+ */
+export const getSumPtsAllTeamsHandler = async (req: Request, res: Response) => {
+    try {
+
+        const year = Number(req.params.year)
+        const sumPts = await Participation.aggregate([
+            {
+                $match: {
+                    year: year
+                }
+            },
+            {
+                $group: {
+                    _id: '$team_id',
+                    sumPoints: { $sum: '$real_pts' },
+                }
+            },
+            {
+                $lookup: {
+                    from: config.db.teamsColl,
+                    localField: '_id',
+                    foreignField: '_id',
+                    as: 'team'
+                }
+            },
+            {
+                $setWindowFields: {
+                    partitionBy: "$state",
+                    sortBy: { sumPoints: -1 },
+                    output: {
+                        rankOrder: {
+                            $rank: {}
+                        }
+                    }
+                }
+            },
+        ])
+        if (sumPts.length == 0) {
+            const msg: resFormat = {
+                message: "no teams points to be found",
+            }
+            return res.status(404).json(msg)
+        }
+
+        // Add percentage field to output
+        let totalSumPts = 0.0
+        for (let i = 0; i < sumPts.length; i++) {
+            totalSumPts += sumPts[i].sumPoints
+        }
+        let sumPtsOutput = []
+        for (let i = 0; i < sumPts.length; i++) {
+
+            sumPtsOutput.push({
+                team_id: sumPts[i].team[0]._id,
+                pos: sumPts[i].rankOrder,
+                team:  sumPts[i].team[0].t_name,
+                sumPts: sumPts[i].sumPoints,
+                percentage: ((sumPts[i].sumPoints / totalSumPts) * 100).toFixed(2) // to 2 decimal places
+            })
+            
+        }
+
+        const msg: resGetALL = {
+            message: "successfully get all teams' sum points",
+            list: sumPtsOutput
+        }
+
+        return res.status(200).json(msg)
+    }
+    catch (err) {
+        console.log("get all teams' sum points error")
+        console.log(err)
+        const msg: resFormat = { message: "get all teams' sum points fail" }
         return res.status(500).json(msg)
     }
 }

--- a/src/docs/Drivers/getAllDrivers.ts
+++ b/src/docs/Drivers/getAllDrivers.ts
@@ -2,9 +2,18 @@ export default {
     // method of operation
     get: {
         tags: ["driver-operations"], 
-        description: "Get all drivers", 
+        description: "Get all drivers and return in place order", 
         operationId: "getAllDriver", 
-        parameters: [], 
+        parameters: [
+            {
+                name: "sort", 
+                in: "query", 
+                schema: {
+                    type: "string"
+                },
+                description: "default sort is by lastname, indicate sort by alphabet by using sort=firstname",
+            },
+        ], 
         // expected responses
         responses: {
             200: {

--- a/src/docs/Drivers/getDriversByYear.ts
+++ b/src/docs/Drivers/getDriversByYear.ts
@@ -14,6 +14,14 @@ export default {
                 required: true, 
                 description: "the year that the drivers participated in",
             },
+            {
+                name: "sort", 
+                in: "query", 
+                schema: {
+                    type: "string"
+                },
+                description: "default sort is by lastname, indicate sort by alphabet by using sort=firstname",
+            },
         ], 
         // expected responses
         responses: {

--- a/src/docs/Drivers/getDriversByYear.ts
+++ b/src/docs/Drivers/getDriversByYear.ts
@@ -1,0 +1,56 @@
+export default {
+    // method of operation
+    get: {
+        tags: ["driver-operations"], 
+        description: "Get all driver in 1 year", 
+        operationId: "getAllDriverByYear", 
+        parameters: [
+            {
+                name: "year", 
+                in: "path", 
+                schema: {
+                    $ref: "#/components/schemas/year", 
+                },
+                required: true, 
+                description: "the year that the drivers participated in",
+            },
+        ], 
+        // expected responses
+        responses: {
+            200: {
+                description: "Received all drivers successfully", 
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: '#/components/schemas/DriverList', 
+                        },
+                    },
+                },
+            },
+            // response code
+            404: {
+                description: "DriverList not found", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+            500: {
+                description: "Internal error", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+        },
+    }
+};

--- a/src/docs/Drivers/getSumPtsAllDrivers.ts
+++ b/src/docs/Drivers/getSumPtsAllDrivers.ts
@@ -1,0 +1,56 @@
+export default {
+    // method of operation
+    get: {
+        tags: ["driver-operations"], 
+        description: "Get all drivers' sum points in 1 year and return in ranking order", 
+        operationId: "getAllDriversSumPtsByYear", 
+        parameters: [
+            {
+                name: "year", 
+                in: "path", 
+                schema: {
+                    $ref: "#/components/schemas/year", 
+                },
+                required: true, 
+                description: "the year that the driver participated in",
+            },
+        ], 
+        // expected responses
+        responses: {
+            200: {
+                description: "Received all drivers' sum points successfully", 
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: '#/components/schemas/SumPtsList', 
+                        },
+                    },
+                },
+            },
+            // response code
+            404: {
+                description: "no drivers points to be found", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+            500: {
+                description: "Internal error", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+        },
+    }
+};

--- a/src/docs/Drivers/index.ts
+++ b/src/docs/Drivers/index.ts
@@ -1,6 +1,7 @@
 import getAllDrivers from './getAllDrivers';
 import getOneDriver from './getOneDriver';
 import getDriversByYear from './getDriversByYear';
+import getSumPtsAllDrivers from './getSumPtsAllDrivers';
 
 export default {
     '/api/v1/drivers': {
@@ -8,6 +9,9 @@ export default {
     },
     '/api/v1/drivers/year/{year}': {
         ...getDriversByYear
+    },
+    '/api/v1/drivers/year/{year}/points': {
+        ...getSumPtsAllDrivers
     },
     '/api/v1/drivers/{id}': {
         ...getOneDriver

--- a/src/docs/Drivers/index.ts
+++ b/src/docs/Drivers/index.ts
@@ -1,11 +1,15 @@
 import getAllDrivers from './getAllDrivers';
 import getOneDriver from './getOneDriver';
+import getDriversByYear from './getDriversByYear';
 
 export default {
     '/api/v1/drivers': {
-        ...getAllDrivers,
+        ...getAllDrivers
+    },
+    '/api/v1/drivers/year/{year}': {
+        ...getDriversByYear
     },
     '/api/v1/drivers/{id}': {
-        ...getOneDriver,
+        ...getOneDriver
     },
 }

--- a/src/docs/GrandPrix/getGPByYear.ts
+++ b/src/docs/GrandPrix/getGPByYear.ts
@@ -1,0 +1,56 @@
+export default {
+    // method of operation
+    get: {
+        tags: ["grandprix-operations"], 
+        description: "Get all grandprix in 1 year", 
+        operationId: "getAllGrandPrixByYear", 
+        parameters: [
+            {
+                name: "year", 
+                in: "path", 
+                schema: {
+                    $ref: "#/components/schemas/year", 
+                },
+                required: true, 
+                description: "the year that the grandprix is held",
+            },
+        ], 
+        // expected responses
+        responses: {
+            200: {
+                description: "Received all grandprix successfully", 
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: '#/components/schemas/GrandPrixList', 
+                        },
+                    },
+                },
+            },
+            // response code
+            404: {
+                description: "GrandPrixList not found", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+            500: {
+                description: "Internal error", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+        },
+    }
+};

--- a/src/docs/GrandPrix/getGPByYear.ts
+++ b/src/docs/GrandPrix/getGPByYear.ts
@@ -14,6 +14,14 @@ export default {
                 required: true, 
                 description: "the year that the grandprix is held",
             },
+            {
+                name: "sort", 
+                in: "query", 
+                schema: {
+                    type: "string"
+                },
+                description: "default sort is by date, indicate sort by place by using sort=place",
+            },
         ], 
         // expected responses
         responses: {

--- a/src/docs/GrandPrix/getWinnersAllGP.ts
+++ b/src/docs/GrandPrix/getWinnersAllGP.ts
@@ -1,0 +1,64 @@
+export default {
+    // method of operation
+    get: {
+        tags: ["grandprix-operations"], 
+        description: "Get all grandprix's winners in 1 year and return in grandprix's date order", 
+        operationId: "getAllGrandPrixWinnerByYear", 
+        parameters: [
+            {
+                name: "year", 
+                in: "path", 
+                schema: {
+                    $ref: "#/components/schemas/year", 
+                },
+                required: true, 
+                description: "the year that the grandprix is held",
+            },
+            {
+                name: "top3", 
+                in: "query", 
+                schema: {
+                    type: "string"
+                },
+                description: "by default show only top 1, to show top3 use top3=true",
+            },
+        ], 
+        // expected responses
+        responses: {
+            200: {
+                description: "Received all grandprix's winners successfully", 
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: '#/components/schemas/WinnerList', 
+                        },
+                    },
+                },
+            },
+            // response code
+            404: {
+                description: "GrandPrix's winners list not found", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+            500: {
+                description: "Internal error", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+        },
+    }
+};

--- a/src/docs/GrandPrix/index.ts
+++ b/src/docs/GrandPrix/index.ts
@@ -1,6 +1,7 @@
 import getAllGrandPrix  from './getAllGrandPrix';
 import getOneGrandPrix from './getOneGrandPrix';
 import getGPByYear from './getGPByYear';
+import getWinnersAllGP from './getWinnersAllGP';
 
 export default {
     '/api/v1/grandprix': {
@@ -8,6 +9,9 @@ export default {
     },
     '/api/v1/grandprix/year/{year}': {
         ...getGPByYear,
+    },
+    '/api/v1/grandprix/year/{year}/winners': {
+        ...getWinnersAllGP,
     },
     '/api/v1/grandprix/{id}': {
         ...getOneGrandPrix,

--- a/src/docs/GrandPrix/index.ts
+++ b/src/docs/GrandPrix/index.ts
@@ -1,8 +1,12 @@
 import getAllGrandPrix  from './getAllGrandPrix';
 import getOneGrandPrix from './getOneGrandPrix';
+import getGPByYear from './getGPByYear';
 
 export default {
     '/api/v1/grandprix': {
+        ...getAllGrandPrix,
+    },
+    '/api/v1/grandprix/year/{year}': {
         ...getAllGrandPrix,
     },
     '/api/v1/grandprix/{id}': {

--- a/src/docs/GrandPrix/index.ts
+++ b/src/docs/GrandPrix/index.ts
@@ -7,7 +7,7 @@ export default {
         ...getAllGrandPrix,
     },
     '/api/v1/grandprix/year/{year}': {
-        ...getAllGrandPrix,
+        ...getGPByYear,
     },
     '/api/v1/grandprix/{id}': {
         ...getOneGrandPrix,

--- a/src/docs/Participation/getParticipationByDriver.ts
+++ b/src/docs/Participation/getParticipationByDriver.ts
@@ -3,7 +3,7 @@ export default {
     get: {
         tags: ["participation-operations"], 
         description: "Get all participation by 1 driver in 1 year", 
-        operationId: "getAllParticipationByGP", 
+        operationId: "getAllParticipationByDriver", 
         parameters: [
             {
                 name: "id", 

--- a/src/docs/Participation/getParticipationByDriver.ts
+++ b/src/docs/Participation/getParticipationByDriver.ts
@@ -32,7 +32,7 @@ export default {
                     // content-type
                     "application/json": {
                         schema: {
-                            $ref: '#/components/schemas/ParticipationList', 
+                            $ref: '#/components/schemas/DriverAllParResponse', 
                         },
                     },
                 },

--- a/src/docs/Participation/getParticipationByTeam.ts
+++ b/src/docs/Participation/getParticipationByTeam.ts
@@ -3,7 +3,7 @@ export default {
     get: {
         tags: ["participation-operations"], 
         description: "Get all participation by 1 team in 1 year", 
-        operationId: "getAllParticipationByGP", 
+        operationId: "getAllParticipationByTeam", 
         parameters: [
             {
                 name: "id", 

--- a/src/docs/Teams/getAllTeams.ts
+++ b/src/docs/Teams/getAllTeams.ts
@@ -2,7 +2,7 @@ export default {
     // method of operation
     get: {
         tags: ["team-operations"], 
-        description: "Get all teams", 
+        description: "Get all teams and return in team_name order", 
         operationId: "getAllTeam", 
         parameters: [], 
         // expected responses

--- a/src/docs/Teams/getSumPtsAllTeams.ts
+++ b/src/docs/Teams/getSumPtsAllTeams.ts
@@ -1,24 +1,15 @@
 export default {
     // method of operation
     get: {
-        tags: ["participation-operations"], 
-        description: "Get all participation by 1 team in 1 year", 
-        operationId: "getAllParticipationByTeam", 
+        tags: ["team-operations"], 
+        description: "Get all teams' sum points in 1 year and return in ranking order", 
+        operationId: "getAllTeamsSumPtsByYear", 
         parameters: [
-            {
-                name: "id", 
-                in: "path", 
-                schema: {
-                  $ref: "#/components/schemas/id", 
-                },
-                required: true, 
-                description: "team id that want to search",
-            },
             {
                 name: "year", 
                 in: "path", 
                 schema: {
-                  $ref: "#/components/schemas/year", 
+                    $ref: "#/components/schemas/year", 
                 },
                 required: true, 
                 description: "the year that the team participated in",
@@ -27,19 +18,19 @@ export default {
         // expected responses
         responses: {
             200: {
-                description: "Received all participation successfully", 
+                description: "Received all teams' sum points successfully", 
                 content: {
                     // content-type
                     "application/json": {
                         schema: {
-                            $ref: '#/components/schemas/TeamAllPartResponse', 
+                            $ref: '#/components/schemas/SumPtsList', 
                         },
                     },
                 },
             },
             // response code
             404: {
-                description: "ParticipationList not found", // response desc.
+                description: "no teams points to be found", // response desc.
                 content: {
                     // content-type
                     "application/json": {

--- a/src/docs/Teams/getTeamsByYear.ts
+++ b/src/docs/Teams/getTeamsByYear.ts
@@ -1,0 +1,56 @@
+export default {
+    // method of operation
+    get: {
+        tags: ["team-operations"], 
+        description: "Get all teams in 1 year", 
+        operationId: "getAllTeamsByYear", 
+        parameters: [
+            {
+                name: "year", 
+                in: "path", 
+                schema: {
+                    $ref: "#/components/schemas/year", 
+                },
+                required: true, 
+                description: "the year that the teams participated in",
+            },
+        ], 
+        // expected responses
+        responses: {
+            200: {
+                description: "Received all teams successfully", 
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: '#/components/schemas/TeamList', 
+                        },
+                    },
+                },
+            },
+            // response code
+            404: {
+                description: "TeamList not found", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+            500: {
+                description: "Internal error", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+        },
+    }
+};

--- a/src/docs/Teams/index.ts
+++ b/src/docs/Teams/index.ts
@@ -1,6 +1,7 @@
 import getOneTeam from './getOneTeam';
 import getAllTeams from './getAllTeams';
 import getTeamsByYear from './getTeamsByYear'
+import getSumPtsAllTeams from './getSumPtsAllTeams';
 
 export default {
     '/api/v1/teams': {
@@ -8,6 +9,9 @@ export default {
     },
     '/api/v1/teams/year/{year}': {
         ...getTeamsByYear,
+    },
+    '/api/v1/teams/year/{year}/points': {
+        ...getSumPtsAllTeams,
     },
     '/api/v1/teams/{id}': {
         ...getOneTeam,

--- a/src/docs/Teams/index.ts
+++ b/src/docs/Teams/index.ts
@@ -1,9 +1,13 @@
 import getOneTeam from './getOneTeam';
 import getAllTeams from './getAllTeams';
+import getTeamsByYear from './getTeamsByYear'
 
 export default {
     '/api/v1/teams': {
         ...getAllTeams,
+    },
+    '/api/v1/teams/year/{year}': {
+        ...getTeamsByYear,
     },
     '/api/v1/teams/{id}': {
         ...getOneTeam,

--- a/src/docs/components.ts
+++ b/src/docs/components.ts
@@ -45,9 +45,13 @@ export default {
                 },
             },
             // Driver model
-            name: {
+            firstname: {
                 type: 'string',
-                example: 'Lewis Hamilton'
+                example: 'lewis'
+            },
+            lastname: {
+                type: 'string',
+                example: 'hamilton'
             },
             nationality: {
                 type: 'string',
@@ -59,8 +63,11 @@ export default {
                     _id: {
                         $ref: '#/components/schemas/id'
                     },
-                    name: {
-                        $ref: '#/components/schemas/name'
+                    firstname: {
+                        $ref: '#/components/schemas/firstname'
+                    },
+                    lastname: {
+                        $ref: '#/components/schemas/lastname'
                     },
                     nationality: {
                         $ref: '#/components/schemas/nationality'

--- a/src/docs/components.ts
+++ b/src/docs/components.ts
@@ -15,7 +15,8 @@ export default {
                 type: "number",
                 example: "2023"
             },
-            
+
+
             GrandPrix: {
                 type: "object",
                 properties: {
@@ -62,7 +63,7 @@ export default {
                     },
                     nationality: {
                         $ref: '#/components/schemas/nationality'
-                        
+
                     }
                 },
             },
@@ -149,7 +150,7 @@ export default {
                 },
             },
             ParticipationList: {
-                type: "array", 
+                type: "array",
                 description: "an array of participation",
                 items: {
                     $ref: '#/components/schemas/Participation'
@@ -160,6 +161,11 @@ export default {
                 type: 'string',
                 desciption: "driver's fullname",
                 example: "Charles Leclerc"
+            },
+            formatedDate: {
+                type: "string",
+                format: "date-time",
+                example: "Mar 20 2022"
             },
             Winner: {
                 type: "object",
@@ -172,9 +178,7 @@ export default {
                         example: "Bahrain"
                     },
                     date: {
-                        type: "string",
-                        format: "date-time",
-                        example: "Mar 20 2022"
+                        $ref: '#/components/schemas/formatedDate'
                     },
                     pos: {
                         $ref: '#/components/schemas/pos'
@@ -194,7 +198,7 @@ export default {
                 },
             },
             WinnerList: {
-                type: "array", 
+                type: "array",
                 description: "an array of winnes of grandprix",
                 items: {
                     $ref: '#/components/schemas/Winner'
@@ -238,56 +242,148 @@ export default {
                 },
             },
             SumPtsList: {
-                type: "array", 
+                type: "array",
                 description: "an array of sum points of drivers",
                 items: {
                     $ref: '#/components/schemas/SumPts'
                 },
             },
             // Driver's all participation in 1 year 
-            DriverOnePar: {
-                type: "object",
-                properties: {
-                    grandprix: {
-                        type: "string",
-                        example: "Bahrain"
-                    },
-                    date: {
-                        type: "string",
-                        format: "date-time",
-                        example: "Mar 20 2022"
-                    },
-                    pos: {
-                        $ref: '#/components/schemas/pos'
-                    },
-                    
-                    team: {
-                        $ref: '#/components/schemas/team_name'
-                    },
-                    points: {
-                        $ref: '#/components/schemas/points'
-                    },
-                    accumPts: {
-                        $ref: '#/components/schemas/points'
-                    },
-                },
-            },
             DriverAllPar: {
-                type: "array", 
+                type: "array",
                 description: "an array of driver racing result of all grandprix in 1 year",
                 items: {
-                    $ref: '#/components/schemas/DriverOnePar'
+                    type: "object",
+                    properties: {
+                        grandprix: {
+                            type: "string",
+                            example: "Bahrain"
+                        },
+                        date: {
+                            $ref: '#/components/schemas/formattedDay'
+                        },
+                        pos: {
+                            $ref: '#/components/schemas/pos'
+                        },
+                        team: {
+                            $ref: '#/components/schemas/team_name'
+                        },
+                        points: {
+                            $ref: '#/components/schemas/points'
+                        },
+                        accumPts: {
+                            $ref: '#/components/schemas/points'
+                        },
+                    },
                 },
             },
             DriverAllParResponse: {
-                type: "object", 
+                type: "object",
                 description: "response format",
                 properties: {
                     target: {
                         $ref: '#/components/schemas/Driver'
                     },
                     list: {
-                        $ref: '#/components/schemas/DriverOnePar'
+                        $ref: '#/components/schemas/DriverAllPar'
+                    }
+                }
+            },
+            // Team sum points 
+            TeamSumPts: {
+                type: "object",
+                properties: {
+                    team_id: {
+                        $ref: '#/components/schemas/id'
+                    },
+                    pos: {
+                        $ref: '#/components/schemas/rank'
+                    },
+                    team: {
+                        $ref: '#/components/schemas/team_name'
+                    },
+                    sumPts: {
+                        $ref: '#/components/schemas/points'
+                    },
+                    percentage: {
+                        $ref: '#/components/schemas/points'
+                    }
+                },
+            },
+            TeamSumPtsList: {
+                type: "array",
+                description: "an array of sum points of teams",
+                items: {
+                    $ref: '#/components/schemas/TeamSumPts'
+                },
+            },
+            // Team's all participation
+            TeamAllPart: {
+                "type": "object",
+                "properties": {
+                    "grandprix": {
+                        $ref: '#/components/schemas/place'
+                    },
+                    "date": {
+                        $ref: '#/components/schemas/formattedDate'
+                    },
+                    "sumPts": {
+                        $ref: '#/components/schemas/points'
+                    },
+                    "accumPts": {
+                        $ref: '#/components/schemas/points'
+                    },
+                    "driverInfos": {
+                        type: "array",
+                        description: "array of drivers of a team who participated in this grandprix",
+                        items: {
+                            "type": "object",
+                            "properties": {
+                                "fullname": {
+                                    $ref: '#/components/schemas/fullname'
+                                },
+                                "pos": {
+                                    $ref: '#/components/schemas/pos'
+                                },
+                                "points": {
+                                    $ref: '#/components/schemas/points'
+                                }
+                            }
+
+                        }
+                    }
+                }
+            },
+            DriverContri: {
+                "type": "object",
+                "properties": {
+                    "driverId": {
+                        "type": "string"
+                    },
+                    "driverName": {
+                        "type": "string"
+                    },
+                    "points": {
+                        "type": "number"
+                    }
+                }
+            },
+            TeamAllPartResponse: {
+                type: "object",
+                description: "response format",
+                properties: {
+                    target: {
+                        $ref: '#/components/schemas/Team'
+                    },
+                    list: {
+                        $ref: '#/components/schemas/TeamAllPart'
+                    },
+                    driverPts: {
+                        type: "array", // data type
+                        description: "an array of driver points and their contribution percentage to team total points in that year",
+                        items: {
+                            $ref: '#/components/schemas/DriverContri'
+                        },
                     }
                 }
             },

--- a/src/docs/components.ts
+++ b/src/docs/components.ts
@@ -244,6 +244,53 @@ export default {
                     $ref: '#/components/schemas/SumPts'
                 },
             },
+            // Driver's all participation in 1 year 
+            DriverOnePar: {
+                type: "object",
+                properties: {
+                    grandprix: {
+                        type: "string",
+                        example: "Bahrain"
+                    },
+                    date: {
+                        type: "string",
+                        format: "date-time",
+                        example: "Mar 20 2022"
+                    },
+                    pos: {
+                        $ref: '#/components/schemas/pos'
+                    },
+                    
+                    team: {
+                        $ref: '#/components/schemas/team_name'
+                    },
+                    points: {
+                        $ref: '#/components/schemas/points'
+                    },
+                    accumPts: {
+                        $ref: '#/components/schemas/points'
+                    },
+                },
+            },
+            DriverAllPar: {
+                type: "array", 
+                description: "an array of driver racing result of all grandprix in 1 year",
+                items: {
+                    $ref: '#/components/schemas/DriverOnePar'
+                },
+            },
+            DriverAllParResponse: {
+                type: "object", 
+                description: "response format",
+                properties: {
+                    target: {
+                        $ref: '#/components/schemas/Driver'
+                    },
+                    list: {
+                        $ref: '#/components/schemas/DriverOnePar'
+                    }
+                }
+            },
             // Error model
             Error: {
                 type: "object", //data type

--- a/src/docs/components.ts
+++ b/src/docs/components.ts
@@ -15,11 +15,7 @@ export default {
                 type: "number",
                 example: "2023"
             },
-            date: {
-                type: "string",
-                format: "date-time",
-                example: "2023-06-18T00:00:00.000Z"
-            },
+            
             GrandPrix: {
                 type: "object",
                 properties: {
@@ -33,7 +29,8 @@ export default {
                         $ref: '#/components/schemas/year'
                     },
                     date: {
-                        $ref: '#/components/schemas/date'
+                        type: "string",
+                        example: "2023-06-18T00:00:00.000Z"
                     },
                 },
             },
@@ -45,14 +42,6 @@ export default {
                 },
             },
             // Driver model
-            firstname: {
-                type: 'string',
-                example: 'lewis'
-            },
-            lastname: {
-                type: 'string',
-                example: 'hamilton'
-            },
             nationality: {
                 type: 'string',
                 example: 'GBR'
@@ -64,14 +53,17 @@ export default {
                         $ref: '#/components/schemas/id'
                     },
                     firstname: {
-                        $ref: '#/components/schemas/firstname'
+                        type: 'string',
+                        example: 'Lewis'
                     },
                     lastname: {
-                        $ref: '#/components/schemas/lastname'
+                        type: 'string',
+                        example: 'Hamilton'
                     },
                     nationality: {
                         $ref: '#/components/schemas/nationality'
-                    },
+                        
+                    }
                 },
             },
             DriverList: {
@@ -82,7 +74,7 @@ export default {
                 },
             },
             // Team model
-            t_name: {
+            team_name: {
                 type: 'string',
                 example: 'Mercedes'
             },
@@ -93,7 +85,7 @@ export default {
                         $ref: '#/components/schemas/id'
                     },
                     t_name: {
-                        $ref: '#/components/schemas/t_name'
+                        $ref: '#/components/schemas/team_name'
                     }
                 },
             },
@@ -142,7 +134,6 @@ export default {
                     time: {
                         $ref: '#/components/schemas/time'
                     },
-
                     laps: {
                         $ref: '#/components/schemas/laps'
                     },
@@ -152,6 +143,9 @@ export default {
                     points: {
                         $ref: '#/components/schemas/points'
                     },
+                    real_pts: {
+                        $ref: '#/components/schemas/points'
+                    },
                 },
             },
             ParticipationList: {
@@ -159,6 +153,95 @@ export default {
                 description: "an array of participation",
                 items: {
                     $ref: '#/components/schemas/Participation'
+                },
+            },
+            // Winner model 
+            fullname: {
+                type: 'string',
+                desciption: "driver's fullname",
+                example: "Charles Leclerc"
+            },
+            Winner: {
+                type: "object",
+                properties: {
+                    gp_id: {
+                        $ref: '#/components/schemas/id'
+                    },
+                    grandprix: {
+                        type: "string",
+                        example: "Bahrain"
+                    },
+                    date: {
+                        type: "string",
+                        format: "date-time",
+                        example: "Mar 20 2022"
+                    },
+                    pos: {
+                        $ref: '#/components/schemas/pos'
+                    },
+                    winner: {
+                        $ref: '#/components/schemas/fullname'
+                    },
+                    team: {
+                        $ref: '#/components/schemas/team_name'
+                    },
+                    time: {
+                        $ref: '#/components/schemas/time'
+                    },
+                    laps: {
+                        $ref: '#/components/schemas/laps'
+                    },
+                },
+            },
+            WinnerList: {
+                type: "array", 
+                description: "an array of winnes of grandprix",
+                items: {
+                    $ref: '#/components/schemas/Winner'
+                },
+            },
+            // SumPts model 
+            rank: {
+                type: 'number',
+                description: "the ranking of results",
+                example: 2
+            },
+            percentage: {
+                type: 'string',
+                description: "percentage of one's result over total results",
+                example: "17.25"
+            },
+            SumPts: {
+                type: "object",
+                properties: {
+                    driver_id: {
+                        $ref: '#/components/schemas/id'
+                    },
+                    pos: {
+                        $ref: '#/components/schemas/rank'
+                    },
+                    driver: {
+                        $ref: '#/components/schemas/fullname'
+                    },
+                    nationality: {
+                        $ref: '#/components/schemas/nationality'
+                    },
+                    team: {
+                        $ref: '#/components/schemas/team_name'
+                    },
+                    sumPts: {
+                        $ref: '#/components/schemas/points'
+                    },
+                    percentage: {
+                        $ref: '#/components/schemas/points'
+                    }
+                },
+            },
+            SumPtsList: {
+                type: "array", 
+                description: "an array of sum points of drivers",
+                items: {
+                    $ref: '#/components/schemas/SumPts'
                 },
             },
             // Error model

--- a/src/models/CHANGELOG.md
+++ b/src/models/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Version 1.1.0
+Date: 02 Jul 2023
+
+**Changes**:
+- Added a new field `real_pts"` to the Participation Model.
+    - `points` field shows original racing result of a driver when client checks 1 specific Grand Prix 
+    - `real_pts` stores points that has been calculated and recorded to driver's final result 
+    - Driver final sum points is calculated based on `real_pts`, but not `points`
+- Modified docs to accommodate the `real_pts` field.
+   
+Author: tten5

--- a/src/models/driver.ts
+++ b/src/models/driver.ts
@@ -3,13 +3,15 @@ import { config } from '../config';
 
 // Create an interface representing a document in MongoDB.
 export interface IDriver {
-    name: string;
+    firstname: string;
+    lastname: string;
     nationality: string;
 }
 
 // Create a Schema corresponding to the document interface.
 const driverSchema = new Schema<IDriver>({
-    name: { type: String, required: true, index: true },
+    firstname: { type: String, required: true, index: true },
+    lastname: { type: String, required: true, index: true },
     nationality: { type: String, required: true }
 },
     { collection: config.db.driversColl });

--- a/src/models/participation.ts
+++ b/src/models/participation.ts
@@ -11,6 +11,7 @@ export interface IParticipation {
     pos: string;
     points: number;
     year: number;
+    real_pts: number;
 }
 
 // Create a Schema corresponding to the document interface.
@@ -31,7 +32,8 @@ const participationSchema = new Schema<IParticipation>({
     laps: { type: Number, required: true },
     pos: { type: String, required: true },
     points: { type: Number, required: true },
-    year: { type: Number, required: true }
+    year: { type: Number, required: true },
+    real_pts: { type: Number, require: true}
 },
     { collection: config.db.participationColl });
 

--- a/src/routes/driver.ts
+++ b/src/routes/driver.ts
@@ -2,7 +2,8 @@ import { Router } from "express"
 import {
     getDriversHandler,
     getOneDriverHandler,
-    getDriversByYearHandler
+    getDriversByYearHandler,
+    getSumPtsAllDriversHandler
 } from "../controllers/driver"
 
 const router = Router()
@@ -10,6 +11,20 @@ const router = Router()
 // CRUD 
 router.get("/", getDriversHandler)
 router.get("/year/:year", getDriversByYearHandler)
+router.get("/year/:year/points", getSumPtsAllDriversHandler)
 router.get("/:id", getOneDriverHandler)
+
+/**
+ * 
+ * 
+ * POST to search for driver with user input /search , default is search by lastname
+ * 
+ * yearly ranknig: /:id/yearly-ranking/ 
+ * 
+ * all participation with specific pos /:id?pos="3"
+ * 
+ * 
+ 
+ */
 
 export default router

--- a/src/routes/driver.ts
+++ b/src/routes/driver.ts
@@ -1,10 +1,15 @@
 import { Router } from "express"
-import { getDriversHandler, getOneDriverHandler } from "../controllers/driver"
+import {
+    getDriversHandler,
+    getOneDriverHandler,
+    getDriversByYearHandler
+} from "../controllers/driver"
 
 const router = Router()
 
 // CRUD 
 router.get("/", getDriversHandler)
+router.get("/year/:year", getDriversByYearHandler)
 router.get("/:id", getOneDriverHandler)
 
 export default router

--- a/src/routes/grandprix.ts
+++ b/src/routes/grandprix.ts
@@ -2,7 +2,8 @@ import { Router } from "express"
 import {
     getAllGPHandler,
     getOneGPHandler,
-    getGPByYearHandler
+    getGPByYearHandler,
+    getWinnersAllGPHandler
 } from '../controllers/grandprix'
 
 const router = Router()
@@ -10,6 +11,15 @@ const router = Router()
 // CRUD 
 router.get("/", getAllGPHandler)
 router.get("/year/:year", getGPByYearHandler)
+router.get("/year/:year/winners", getWinnersAllGPHandler)
 router.get("/:id", getOneGPHandler)
 
+/*
+search by place: get /places/ -> return all places 
+
+POST to search for place with user input /search
+
+yearly winner of gp from 1 place: /:id/yearly-winners&top3=true
+
+*/
 export default router

--- a/src/routes/grandprix.ts
+++ b/src/routes/grandprix.ts
@@ -1,10 +1,15 @@
 import { Router } from "express"
-import { getAllGPHandler, getOneGPHandler } from '../controllers/grandprix'
+import {
+    getAllGPHandler,
+    getOneGPHandler,
+    getGPByYearHandler
+} from '../controllers/grandprix'
 
 const router = Router()
 
 // CRUD 
 router.get("/", getAllGPHandler)
+router.get("/year/:year", getGPByYearHandler)
 router.get("/:id", getOneGPHandler)
 
 export default router

--- a/src/routes/team.ts
+++ b/src/routes/team.ts
@@ -12,4 +12,18 @@ router.get("/", getTeamsHandler)
 router.get("/year/:year", getTeamsByYearHandler)
 router.get("/:id", getOneTeamHandler)
 
+/**
+ * by year and driver and all -> get /year/:year/points
+ * 
+ * POST to search for driver with user input /search , 
+ * 
+ * yearly ranknig: /:id/yearly-ranking/ 
+ * team's best driver over year /:id/yearly-best-driver
+ * 
+ * 
+ * 
+ * 
+ 
+ */
+
 export default router

--- a/src/routes/team.ts
+++ b/src/routes/team.ts
@@ -1,10 +1,15 @@
 import { Router } from "express"
-import { getTeamsHandler, getOneTeamHandler } from "../controllers/team"
+import {
+    getTeamsHandler,
+    getOneTeamHandler,
+    getTeamsByYearHandler
+} from "../controllers/team"
 
 const router = Router()
 
 // CRUD 
 router.get("/", getTeamsHandler)
+router.get("/year/:year", getTeamsByYearHandler)
 router.get("/:id", getOneTeamHandler)
 
 export default router

--- a/src/routes/team.ts
+++ b/src/routes/team.ts
@@ -2,7 +2,8 @@ import { Router } from "express"
 import {
     getTeamsHandler,
     getOneTeamHandler,
-    getTeamsByYearHandler
+    getTeamsByYearHandler,
+    getSumPtsAllTeamsHandler
 } from "../controllers/team"
 
 const router = Router()
@@ -10,6 +11,7 @@ const router = Router()
 // CRUD 
 router.get("/", getTeamsHandler)
 router.get("/year/:year", getTeamsByYearHandler)
+router.get("/year/:year/points", getSumPtsAllTeamsHandler)
 router.get("/:id", getOneTeamHandler)
 
 /**

--- a/src/test/test_driver.ts
+++ b/src/test/test_driver.ts
@@ -10,11 +10,29 @@ describe('Driver API', () => {
             assert.isArray(response.data.list);
             assert.isAbove(response.data.list.length, 0);
         });
+        it('should return driver list in firstname order when sort=firstname', async () => {
+            const response = await requestInstance.get(`/drivers?sort=firstname`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            for (let i = 1; i < response.data.list.length; i++) {
+              assert.ok(response.data.list[i].firstname >= response.data.list[i - 1].firstname, 'Driver list is not in firstname order');
+            }
+        });
+        it('should return driver list in lastname order when sort is not firstname', async () => {
+            const response = await requestInstance.get(`/drivers?sort=what`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            for (let i = 1; i < response.data.list.length; i++) {
+              assert.ok(response.data.list[i].lastname >= response.data.list[i - 1].lastname, 'Driver list are not in lastname order');
+            }
+        });
     });
 
     describe('GET /drivers/:id', () => {
         it('should return a specific driver', async () => {
-            const driverId = '649d4ddb61c89321f5d7ebe3';
+            const driverId = '649ff5b00a1a8712625a720b';
             const response = await requestInstance.get(`/drivers/${driverId}`);
             assert.strictEqual(response.status, 200);
             assert.strictEqual(response.data.target._id, driverId);
@@ -22,7 +40,7 @@ describe('Driver API', () => {
 
         it('should return 404 if driver not found', async () => {
             try {
-                const nonExistentId = '649d3c55e81209641c7096c3'; // Replace with a non-existent driver id
+                const nonExistentId = '649ff5b00a1a8712625a710b'; // Replace with a non-existent driver id
                 await requestInstance.get(`/drivers/${nonExistentId}`);
             }
             catch(err:any) {
@@ -34,7 +52,7 @@ describe('Driver API', () => {
         });
     });
 
-    describe('GET /drivers/year/:year', () => {
+    describe('GET /drivers/year/:year&sort=', () => {
         it('should return all drivers in 1 year', async () => {
             const year = 2014
             const response = await requestInstance.get(`/drivers/year/${year}`);
@@ -54,6 +72,26 @@ describe('Driver API', () => {
                 return
             }
             throw `Should throw error but did not`
+        });
+        it('should return drivers in 1 year in firstname order when sort=firstname', async () => {
+            const year = 2014
+            const response = await requestInstance.get(`/drivers/year/${year}?sort=firstname`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            for (let i = 1; i < response.data.list.length; i++) {
+              assert.ok(response.data.list[i].firstname >= response.data.list[i - 1].firstname, 'Driver list is not in firstname order');
+            }
+        });
+        it('should return drivers in 1 year in lastname order when sort is not firstname', async () => {
+            const year = 2014
+            const response = await requestInstance.get(`/drivers/year/${year}?sort=what`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            for (let i = 1; i < response.data.list.length; i++) {
+              assert.ok(response.data.list[i].lastname >= response.data.list[i - 1].lastname, 'Driver list are not in lastname order');
+            }
         });
     });
 });

--- a/src/test/test_driver.ts
+++ b/src/test/test_driver.ts
@@ -32,7 +32,7 @@ describe('Driver API', () => {
 
     describe('GET /drivers/:id', () => {
         it('should return a specific driver', async () => {
-            const driverId = '649ff5b00a1a8712625a720b';
+            const driverId = '64a0347faa416f5926961dd4';
             const response = await requestInstance.get(`/drivers/${driverId}`);
             assert.strictEqual(response.status, 200);
             assert.strictEqual(response.data.target._id, driverId);
@@ -40,7 +40,7 @@ describe('Driver API', () => {
 
         it('should return 404 if driver not found', async () => {
             try {
-                const nonExistentId = '649ff5b00a1a8712625a710b'; // Replace with a non-existent driver id
+                const nonExistentId = '64a0347faa416f5926961dd3'; // Replace with a non-existent driver id
                 await requestInstance.get(`/drivers/${nonExistentId}`);
             }
             catch(err:any) {
@@ -92,6 +92,32 @@ describe('Driver API', () => {
             for (let i = 1; i < response.data.list.length; i++) {
               assert.ok(response.data.list[i].lastname >= response.data.list[i - 1].lastname, 'Driver list are not in lastname order');
             }
+        });
+    });
+
+    describe('GET /drivers/year/:year/points', () => {
+        it('should return all drivers sum points in 1 year in rank order', async () => {
+            const year = 2014
+            const response = await requestInstance.get(`/drivers/year/${year}/points`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            const testParticipation = await requestInstance.get(`/participation/driver/${response.data.list[0].driver_id}/${year}`);
+            assert.isAbove(testParticipation.data.list.length, 0);
+            assert.strictEqual(response.data.list[0].pos, 1);
+            assert.strictEqual(response.data.list[1].pos, 2);
+            assert.isTrue(response.data.list[0].sumPts > response.data.list[1].sumPts);
+        });
+        it('should return 404 if find sum points of invalid year', async () => {
+            try {
+                const response = await requestInstance.get(`/drivers/year/2012/points`);
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'there is no driver in that year');
+                return
+            }
+            throw `Should throw error but did not`
         });
     });
 });

--- a/src/test/test_driver.ts
+++ b/src/test/test_driver.ts
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
 import requestInstance from './client';
+import { Participation } from '../models/participation';
 
 describe('Driver API', () => {
     describe('GET /drivers', () => {
@@ -27,6 +28,29 @@ describe('Driver API', () => {
             catch(err:any) {
                 assert.strictEqual(err.response.status, 404);
                 assert.strictEqual(err.response.data.message, 'driver not found');
+                return
+            }
+            throw `Should throw error but did not`
+        });
+    });
+
+    describe('GET /drivers/year/:year', () => {
+        it('should return all drivers in 1 year', async () => {
+            const year = 2014
+            const response = await requestInstance.get(`/drivers/year/${year}`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            const testParticipation = await requestInstance.get(`/participation/driver/${response.data.list[0]._id}/${year}`);
+            assert.isAbove(testParticipation.data.list.length, 0);
+        });
+        it('should return 404 if driver of invalid year', async () => {
+            try {
+                const response = await requestInstance.get(`/drivers/year/2012`);            
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'there is no driver in that year');
                 return
             }
             throw `Should throw error but did not`

--- a/src/test/test_driver.ts
+++ b/src/test/test_driver.ts
@@ -114,7 +114,7 @@ describe('Driver API', () => {
             }
             catch (err: any) {
                 assert.strictEqual(err.response.status, 404);
-                assert.strictEqual(err.response.data.message, 'there is no driver in that year');
+                assert.strictEqual(err.response.data.message, 'no drivers points to be found');
                 return
             }
             throw `Should throw error but did not`

--- a/src/test/test_grandprix.ts
+++ b/src/test/test_grandprix.ts
@@ -79,4 +79,37 @@ describe('Grand Prix API', () => {
             }
         });
     });
+
+    describe('GET /grandprix/year/:year/winners?top', () => {
+        it('should return all grandprix winners in 1 year with only top 1', async () => {
+            const year = 2014
+            const response = await requestInstance.get(`/grandprix/year/${year}/winners`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            assert.strictEqual(response.data.list[0].date.slice(-4), String(year));
+            assert.strictEqual(response.data.list[0].pos, "1")
+            assert.strictEqual(response.data.list[1].pos, "1")
+        });
+        it('should return all grandprix winners in 1 year with top3 when top3=true', async () => {
+            const year = 2014
+            const response = await requestInstance.get(`/grandprix/year/${year}/winners?top3=true`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            assert.strictEqual(response.data.list[0].date.slice(-4), String(year));
+            assert.strictEqual(response.data.list[0].pos, "1")
+            assert.strictEqual(response.data.list[1].pos, "2")
+        });
+        it('should return all grandprix winners in 1 year with only top 1 if top3 not equal to true', async () => {
+            const year = 2014
+            const response = await requestInstance.get(`/grandprix/year/${year}/winners?top3=what`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            assert.strictEqual(response.data.list[0].date.slice(-4), String(year));
+            assert.strictEqual(response.data.list[0].pos, "1")
+            assert.strictEqual(response.data.list[1].pos, "1")
+        });
+    });
 });

--- a/src/test/test_grandprix.ts
+++ b/src/test/test_grandprix.ts
@@ -3,11 +3,14 @@ import requestInstance from './client';
 
 describe('Grand Prix API', () => {
     describe('GET /grandprix', () => {
-        it('should return all grand prix', async () => {
+        it('should return all grand prix in place order', async () => {
             const response = await requestInstance.get('/grandprix');
             assert.strictEqual(response.status, 200);
             assert.isArray(response.data.list);
             assert.isAbove(response.data.list.length, 0);
+            for (let i = 1; i < response.data.list.length; i++) {
+                assert.ok(response.data.list[i].place >= response.data.list[i - 1].place, 'Grandprix are not in place order');
+              }
         });
     });
 
@@ -33,7 +36,7 @@ describe('Grand Prix API', () => {
         });
     });
 
-    describe('GET /grandprix/year/:year', () => {
+    describe('GET /grandprix/year/:year?sort', () => {
         it('should return all grandprix in 1 year', async () => {
             const year = 2014
             const response = await requestInstance.get(`/grandprix/year/${year}`);
@@ -52,6 +55,28 @@ describe('Grand Prix API', () => {
                 return
             }
             throw `Should throw error but did not`
+        });
+        it('should return grandprix list in place order when sort=place', async () => {
+            const year = 2014
+            const response = await requestInstance.get(`/grandprix/year/${year}?sort=place`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            assert.strictEqual(response.data.list[0].year, year);
+            for (let i = 1; i < response.data.list.length; i++) {
+              assert.ok(response.data.list[i].place >= response.data.list[i - 1].place, 'Grandprix are not in place order');
+            }
+        });
+        it('should return grandprix list in date order when sort is not place', async () => {
+            const year = 2014
+            const response = await requestInstance.get(`/grandprix/year/${year}?sort=what`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            assert.strictEqual(response.data.list[0].year, year);
+            for (let i = 1; i < response.data.list.length; i++) {
+              assert.ok(response.data.list[i].date >= response.data.list[i - 1].date, 'Grandprix are not in date order');
+            }
         });
     });
 });

--- a/src/test/test_grandprix.ts
+++ b/src/test/test_grandprix.ts
@@ -32,4 +32,26 @@ describe('Grand Prix API', () => {
             throw `Should throw error but did not`
         });
     });
+
+    describe('GET /grandprix/year/:year', () => {
+        it('should return all grandprix in 1 year', async () => {
+            const year = 2014
+            const response = await requestInstance.get(`/grandprix/year/${year}`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            assert.strictEqual(response.data.list[0].year, year);
+        });
+        it('should return 404 if grandprix of invalid year', async () => {
+            try {
+                const response = await requestInstance.get(`/grandprix/year/2012`);            
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'there is no grandprix in that year');
+                return
+            }
+            throw `Should throw error but did not`
+        });
+    });
 });

--- a/src/test/test_participation.ts
+++ b/src/test/test_participation.ts
@@ -34,10 +34,11 @@ describe('Participation API', () => {
             const year = 2014
             const response = await requestInstance.get(`/participation/driver/${driverId}/${year}`);
             assert.strictEqual(response.status, 200);
+            assert.strictEqual(response.data.target._id, driverId);
             assert.isArray(response.data.list);
             assert.isAbove(response.data.list.length, 0);
-            assert.strictEqual(response.data.list[0].driver_id, driverId);
-            assert.strictEqual(response.data.list[0].year, year);
+            assert.strictEqual(response.data.list[0].date.slice(-4), String(year));
+            assert.isTrue(response.data.list[1].accumPts === response.data.list[0].accumPts + response.data.list[1].points);
         });
         it('should return 404 if participation of invalid driver id with valid year', async () => {
             try {

--- a/src/test/test_participation.ts
+++ b/src/test/test_participation.ts
@@ -30,7 +30,7 @@ describe('Participation API', () => {
 
     describe('GET /participation/driver/:id/:year', () => {
         it('should return all participation of 1 driver in 1 year', async () => {
-            const driverId = '649d4ddb61c89321f5d7ebd5'
+            const driverId = '649ff5b00a1a8712625a720b'
             const year = 2014
             const response = await requestInstance.get(`/participation/driver/${driverId}/${year}`);
             assert.strictEqual(response.status, 200);
@@ -80,7 +80,7 @@ describe('Participation API', () => {
         });
         it('should return 404 if participation of invalid team id with valid year', async () => {
             try {
-                const nonExistentId = '649d794f987b834ba97b0f8a'; // Replace with a non-existent participation id
+                const nonExistentId = '649ff7c71319ba1b46c06852'; // Replace with a non-existent participation id
                 await requestInstance.get(`/participation/team/${nonExistentId}/2014`);
             }
             catch (err: any) {
@@ -109,10 +109,10 @@ describe('Participation API', () => {
 
     describe('GET /participation/:id', () => {
         it('should return a specific participation', async () => {
-            const grandPrixId = '649d794f987b834ba97b0f8a';
-            const response = await requestInstance.get(`/participation/${grandPrixId}`);
+            const participationId = '649ff7c71319ba1b46c06854';
+            const response = await requestInstance.get(`/participation/${participationId}`);
             assert.strictEqual(response.status, 200);
-            assert.strictEqual(response.data.target._id, grandPrixId);
+            assert.strictEqual(response.data.target._id, participationId);
         });
 
         it('should return 404 if participation not found', async () => {

--- a/src/test/test_participation.ts
+++ b/src/test/test_participation.ts
@@ -9,6 +9,8 @@ describe('Participation API', () => {
             assert.strictEqual(response.status, 200);
             assert.isArray(response.data.list);
             assert.isAbove(response.data.list.length, 0);
+            assert.strictEqual(response.data.list[0].gp_id, grandprixId);
+
         });
         it('should return 404 if participation of invalid grand prix', async () => {
             try {
@@ -34,6 +36,8 @@ describe('Participation API', () => {
             assert.strictEqual(response.status, 200);
             assert.isArray(response.data.list);
             assert.isAbove(response.data.list.length, 0);
+            assert.strictEqual(response.data.list[0].driver_id, driverId);
+            assert.strictEqual(response.data.list[0].year, year);
         });
         it('should return 404 if participation of invalid driver id with valid year', async () => {
             try {
@@ -63,7 +67,6 @@ describe('Participation API', () => {
     });
 
 
-
     describe('GET /participation/team/:id/:year', () => {
         it('should return all participation of 1 team in 1 year', async () => {
             const teamId = '649d42fb8f9d812c3201f569'
@@ -72,6 +75,8 @@ describe('Participation API', () => {
             assert.strictEqual(response.status, 200);
             assert.isArray(response.data.list);
             assert.isAbove(response.data.list.length, 0);
+            assert.strictEqual(response.data.list[0].team_id, teamId);
+            assert.strictEqual(response.data.list[0].year, year);
         });
         it('should return 404 if participation of invalid team id with valid year', async () => {
             try {

--- a/src/test/test_participation.ts
+++ b/src/test/test_participation.ts
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
 import requestInstance from './client';
+import { Participation } from '../models/participation';
 
 describe('Participation API', () => {
     describe('GET /participation/grandprix/:id', () => {
@@ -76,8 +77,11 @@ describe('Participation API', () => {
             assert.strictEqual(response.status, 200);
             assert.isArray(response.data.list);
             assert.isAbove(response.data.list.length, 0);
-            assert.strictEqual(response.data.list[0].team_id, teamId);
-            assert.strictEqual(response.data.list[0].year, year);
+            assert.exists(response.data.driverPts)
+            assert.exists(response.data.list[0].driverInfos)
+            assert.strictEqual(response.data.target._id, teamId)
+            assert.isTrue(response.data.list[1].accumPts === response.data.list[0].accumPts + response.data.list[1].sumPts);
+            assert.strictEqual(response.data.list[0].date.slice(-4), String(year));
         });
         it('should return 404 if participation of invalid team id with valid year', async () => {
             try {

--- a/src/test/test_participation.ts
+++ b/src/test/test_participation.ts
@@ -30,7 +30,7 @@ describe('Participation API', () => {
 
     describe('GET /participation/driver/:id/:year', () => {
         it('should return all participation of 1 driver in 1 year', async () => {
-            const driverId = '649ff5b00a1a8712625a720b'
+            const driverId = '64a0347faa416f5926961dd4'
             const year = 2014
             const response = await requestInstance.get(`/participation/driver/${driverId}/${year}`);
             assert.strictEqual(response.status, 200);
@@ -109,7 +109,7 @@ describe('Participation API', () => {
 
     describe('GET /participation/:id', () => {
         it('should return a specific participation', async () => {
-            const participationId = '649ff7c71319ba1b46c06854';
+            const participationId = '64a035e966d5ff3b3fcf67e2';
             const response = await requestInstance.get(`/participation/${participationId}`);
             assert.strictEqual(response.status, 200);
             assert.strictEqual(response.data.target._id, participationId);
@@ -117,7 +117,7 @@ describe('Participation API', () => {
 
         it('should return 404 if participation not found', async () => {
             try {
-                const nonExistentId = '649d3c55e81209641c7096c3'; // Replace with a non-existent participation id
+                const nonExistentId = '64a035e966d5ff3b3fcf67e1'; // Replace with a non-existent participation id
                 await requestInstance.get(`/participation/${nonExistentId}`);
             }
             catch (err: any) {

--- a/src/test/test_team.ts
+++ b/src/test/test_team.ts
@@ -1,4 +1,5 @@
 import { assert } from 'chai';
+import { Participation } from '../models/participation';
 import requestInstance from './client';
 
 describe('Team API', () => {
@@ -27,6 +28,29 @@ describe('Team API', () => {
             catch(err:any) {
                 assert.strictEqual(err.response.status, 404);
                 assert.strictEqual(err.response.data.message, 'team not found');
+                return
+            }
+            throw `Should throw error but did not`
+        });
+    });
+
+    describe('GET /teams/year/:year', () => {
+        it('should return all teams in 1 year', async () => {
+            const year = 2014
+            const response = await requestInstance.get(`/teams/year/${year}`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            const testParticipation = await requestInstance.get(`/participation/team/${response.data.list[0]._id}/${year}`);
+            assert.isAbove(testParticipation.data.list.length, 0);
+        });
+        it('should return 404 if team of invalid year', async () => {
+            try {
+                const response = await requestInstance.get(`/teams/year/2012`);            
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'there is no team in that year');
                 return
             }
             throw `Should throw error but did not`

--- a/src/test/test_team.ts
+++ b/src/test/test_team.ts
@@ -1,5 +1,4 @@
 import { assert } from 'chai';
-import { Participation } from '../models/participation';
 import requestInstance from './client';
 
 describe('Team API', () => {
@@ -54,6 +53,32 @@ describe('Team API', () => {
             catch (err: any) {
                 assert.strictEqual(err.response.status, 404);
                 assert.strictEqual(err.response.data.message, 'there is no team in that year');
+                return
+            }
+            throw `Should throw error but did not`
+        });
+    });
+
+    describe('GET /teams/year/:year/points', () => {
+        it('should return all teams sum points in 1 year in rank order', async () => {
+            const year = 2014
+            const response = await requestInstance.get(`/teams/year/${year}/points`);
+            assert.strictEqual(response.status, 200);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            const testParticipation = await requestInstance.get(`/participation/team/${response.data.list[0].team_id}/${year}`);
+            assert.isAbove(testParticipation.data.list.length, 0);
+            assert.strictEqual(response.data.list[0].pos, 1);
+            assert.strictEqual(response.data.list[1].pos, 2);
+            assert.isTrue(response.data.list[0].sumPts > response.data.list[1].sumPts);
+        });
+        it('should return 404 if find sum points of invalid year', async () => {
+            try {
+                const response = await requestInstance.get(`/teams/year/2012/points`);
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'no teams points to be found');
                 return
             }
             throw `Should throw error but did not`

--- a/src/test/test_team.ts
+++ b/src/test/test_team.ts
@@ -35,7 +35,7 @@ describe('Team API', () => {
     });
 
     describe('GET /teams/year/:year', () => {
-        it('should return all teams in 1 year', async () => {
+        it('should return all teams in 1 year and sort in alphabetical order', async () => {
             const year = 2014
             const response = await requestInstance.get(`/teams/year/${year}`);
             assert.strictEqual(response.status, 200);
@@ -43,6 +43,9 @@ describe('Team API', () => {
             assert.isAbove(response.data.list.length, 0);
             const testParticipation = await requestInstance.get(`/participation/team/${response.data.list[0]._id}/${year}`);
             assert.isAbove(testParticipation.data.list.length, 0);
+            for (let i = 1; i < response.data.list.length; i++) {
+                assert.ok(response.data.list[i].t_name >= response.data.list[i - 1].t_name, 'Grandprix are not in alphabetical order');
+              }
         });
         it('should return 404 if team of invalid year', async () => {
             try {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -25,8 +25,17 @@ export interface ISumPts {
     percentage: string;
 }
 
+export interface IDriverParti {
+    grandprix: string;
+    date: string;
+    pos: string;
+    team: string;
+    points: number;
+    accumPts: number;
+}
 
-type validTarget = IGrandPrix | IDriver | ITeam | IParticipation | IWinner | ISumPts
+
+type validTarget = IGrandPrix | IDriver | ITeam | IParticipation | IWinner | ISumPts | IDriverParti
 
 
 export interface resFormat {
@@ -39,6 +48,11 @@ export interface resGetALL extends resFormat{
 
 export interface resGetOne extends resFormat{
     target: validTarget
+}
+
+export interface resGetAllOfOne extends resFormat{
+    target: validTarget;
+    list: validTarget[]
 }
 
 export interface driverSearchParam {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -34,8 +34,24 @@ export interface IDriverParti {
     accumPts: number;
 }
 
+export interface ITeamSumPts {
+    team_id: string;
+    pos: number; 
+    team: string; 
+    sumPts: number; 
+    percentage: string;
+}
 
-type validTarget = IGrandPrix | IDriver | ITeam | IParticipation | IWinner | ISumPts | IDriverParti
+export interface ITeamParti {
+    grandprix: string;
+    date: string;
+    sumPts: number;
+    accumPts: number;
+    driverInfos: driverContri[];
+}
+
+type validTarget = IGrandPrix | IDriver | ITeam | IParticipation
+    | IWinner | ISumPts | IDriverParti | ITeamSumPts | ITeamParti
 
 
 export interface resFormat {
@@ -55,6 +71,10 @@ export interface resGetAllOfOne extends resFormat{
     list: validTarget[]
 }
 
+export interface resGetAllOfOneTeam extends resGetAllOfOne{
+    driverPts: driverContri[]
+}
+
 export interface driverSearchParam {
     driverName: string;
     isLastName: boolean; // default is True
@@ -66,4 +86,10 @@ export interface teamSearchParam {
 
 export interface grandprixSearchParam {
     grandprixPlace: string;
+}
+
+export type driverContri = {
+    fullname: string;
+    pos: string;
+    points: number;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -21,15 +21,12 @@ export interface resGetOne extends resFormat{
 
 export interface driverSearchParam {
     driverName: string;
-    ranking: boolean;
 }
 
 export interface teamSearchParam {
     teamName: string;
-    ranking: boolean;
 }
 
 export interface grandprixSearchParam {
     grandprixPlace: string;
-    winners: boolean;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,7 +4,29 @@ import { ITeam } from "../models/team";
 import { IParticipation } from "../models/participation";
 import { IUser } from "../models/user";
 
-type validTarget = IGrandPrix | IDriver | ITeam | IParticipation | IUser
+export interface IWinner { 
+    gp_id: string;
+    grandprix: string;
+    date: string;
+    pos: string;
+    winner: string;
+    team: string;
+    laps: number;
+    time: string;
+}
+
+export interface ISumPts { 
+    driver_id: string;
+    pos: number;
+    driver: string;
+    nationality: string;
+    team: string;
+    sumPts: number;
+    percentage: string;
+}
+
+
+type validTarget = IGrandPrix | IDriver | ITeam | IParticipation | IWinner | ISumPts
 
 
 export interface resFormat {
@@ -21,6 +43,7 @@ export interface resGetOne extends resFormat{
 
 export interface driverSearchParam {
     driverName: string;
+    isLastName: boolean; // default is True
 }
 
 export interface teamSearchParam {


### PR DESCRIPTION
## Done
- Add routes to get values by year:
    - Get values by 1-year-all-grandprix 
        -  `?sort` by default is by date, can allow to sort by `place`
        - Query top3=true then show top 3 
    - Get values by 1-year-all-drivers
        - Show ranking, driver, nationality, team, sumPoints
        - Show percentage of each driver points in total points of all drivers in a year
    - Get values by 1-year-1-driver
        - Show gp_place, date, team_name, position, points
        - Add accumulativePoints column 
    - Get values by 1-year-all-teams
         - Show percentage of each team points in total points of all teams in a year
    - Get values by 1-year-1-team
        - Add sum points column 
        - At each grandprix, show the participation of that team's members in that grandprix. So that we can see who is the member of that team and how much points they made in the race.
      -  Also return `driverPts` to show how much a driver contribute to team total points by percentage

- Add unittest and auto-docs for all update 

## Test result 
![image](https://github.com/tten5/F1ResultsApp/assets/71060912/48ee5a0a-a44f-45c8-a23a-5ba6ed0eed81)

