### PR TITLE
Add routes to search by driver

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -10,6 +10,8 @@ type dbConfigType = {
     driversColl: string;
     participationColl: string;
     teamsColl: string;
+    yearStart: number;
+    yearEnd: number;
 }
 
 type serverConfigType = {
@@ -29,6 +31,8 @@ export const config : configType = {
         driversColl: "drivers",
         participationColl: "participation",
         teamsColl: "teams",
+        yearStart: 2014,
+        yearEnd: 2023
     },
     server: {
         port: SERVER_PORT

--- a/src/controllers/grandprix.ts
+++ b/src/controllers/grandprix.ts
@@ -135,7 +135,7 @@ export const getWinnersAllGPHandler = async (req: Request, res: Response) => {
             const winnerFirstname = winners[i].driver[0].firstname
             const winnerLastname = winners[i].driver[0].lastname
             const formattedDate = winners[i].grandprix[0].date.
-                toLocaleDateString('en-US', options).replace(',', '');;
+                toLocaleDateString('en-US', options).replace(',', '');
 
             winnersOutput.push({
                 gp_id: winners[i].grandprix[0]._id,

--- a/src/docs/Drivers/getYearlyRankingOfDriver.ts
+++ b/src/docs/Drivers/getYearlyRankingOfDriver.ts
@@ -1,0 +1,55 @@
+export default {
+    // method of operation
+    get: {
+        tags: ["driver-operations"], 
+        description: "Get yearly ranking of a driver", 
+        operationId: "getYearlyRankingOfDriver", 
+        parameters: [
+            {
+                name: "id", 
+                in: "path", 
+                schema: {
+                    type: "string"
+                },
+                description: "id of driver",
+            },
+        ], 
+        // expected responses
+        responses: {
+            200: {
+                description: "Received yearly ranking of driver successfully", 
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: '#/components/schemas/DriverYearlyRankingList', 
+                        },
+                    },
+                },
+            },
+            // response code
+            404: {
+                description: "driver not found", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+            500: {
+                description: "Internal error", // response desc.
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", // error data model
+                        },
+                    },
+                },
+            },
+        },
+    }
+};

--- a/src/docs/Drivers/index.ts
+++ b/src/docs/Drivers/index.ts
@@ -2,6 +2,8 @@ import getAllDrivers from './getAllDrivers';
 import getOneDriver from './getOneDriver';
 import getDriversByYear from './getDriversByYear';
 import getSumPtsAllDrivers from './getSumPtsAllDrivers';
+import searchDriversByName from './searchDriversByName';
+import getYearlyRankingOfDriver from './getYearlyRankingOfDriver';
 
 export default {
     '/api/v1/drivers': {
@@ -15,5 +17,11 @@ export default {
     },
     '/api/v1/drivers/{id}': {
         ...getOneDriver
+    },
+    '/api/v1/drivers/search': {
+        ...searchDriversByName
+    },
+    '/api/v1/drivers/{id}/yearly-ranking': {
+        ...getYearlyRankingOfDriver
     },
 }

--- a/src/docs/Drivers/searchDriversByName.ts
+++ b/src/docs/Drivers/searchDriversByName.ts
@@ -1,0 +1,66 @@
+export default {
+    post: {
+        tags: ["driver-operations"],
+        description: "search driver(s) by name",
+        operationId: "getDriversByName",
+        parameters: [],
+        requestBody: {
+            content: {
+                // content-type
+                "application/json": {
+                    schema: {
+                        $ref: "#/components/schemas/DriverInput",
+                    },
+                },
+            },
+        },
+        // expected responses
+        responses: {
+            200: {
+                description: "Received driver(s) by name successfully",
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: '#/components/schemas/DriverList',
+                        },
+                    },
+                },
+            },
+            // response code
+            404: {
+                description: "Driver(s) not found", 
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", 
+                        },
+                    },
+                },
+            },
+            400: {
+                description: "not valid input", 
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", 
+                        },
+                    },
+                },
+            },
+            500: {
+                description: "Internal error", 
+                content: {
+                    // content-type
+                    "application/json": {
+                        schema: {
+                            $ref: "#/components/schemas/Error", 
+                        },
+                    },
+                },
+            },
+        }
+    }
+};

--- a/src/docs/components.ts
+++ b/src/docs/components.ts
@@ -47,6 +47,10 @@ export default {
                 type: 'string',
                 example: 'GBR'
             },
+            lastname: {
+                type: 'string',
+                example: 'Hamilton'
+            },
             Driver: {
                 type: "object",
                 properties: {
@@ -58,12 +62,10 @@ export default {
                         example: 'Lewis'
                     },
                     lastname: {
-                        type: 'string',
-                        example: 'Hamilton'
+                        $ref: '#/components/schemas/lastname'
                     },
                     nationality: {
                         $ref: '#/components/schemas/nationality'
-
                     }
                 },
             },
@@ -72,6 +74,20 @@ export default {
                 description: "an array of drivers",
                 items: {
                     $ref: '#/components/schemas/Driver'
+                },
+            },
+            DriverInput: {
+                type: "object", // data type
+                description: "request to find driver by name",
+                properties: {
+                    driverName: {
+                        $ref: '#/components/schemas/lastname'
+                    },
+                    isLastName: {
+                        type: "boolean",
+                        description: "search by lastname or not",
+                        default: true
+                    }
                 },
             },
             // Team model
@@ -162,7 +178,7 @@ export default {
                 desciption: "driver's fullname",
                 example: "Charles Leclerc"
             },
-            formatedDate: {
+            formattedDate: {
                 type: "string",
                 format: "date-time",
                 example: "Mar 20 2022"
@@ -178,7 +194,7 @@ export default {
                         example: "Bahrain"
                     },
                     date: {
-                        $ref: '#/components/schemas/formatedDate'
+                        $ref: '#/components/schemas/formattedDate'
                     },
                     pos: {
                         $ref: '#/components/schemas/pos'
@@ -386,6 +402,31 @@ export default {
                         },
                     }
                 }
+            },
+            // diver yearly ranking
+            DriverYearlyRankingList: {
+                type: "array", // data type
+                description: "an array of yearly ranking of a driver",
+                items: {
+                    "type": "object",
+                    "properties": {
+                        "rank": {
+                            $ref: '#/components/schemas/rank'
+                        },
+                        "team": {
+                            $ref: '#/components/schemas/team_name'
+                        },
+                        "sumPts": {
+                            $ref: '#/components/schemas/points'
+                        },
+                        "rankChanged": {
+                            $ref: '#/components/schemas/rank'
+                        },
+                        "year": {
+                            $ref: '#/components/schemas/year'
+                        }
+                    }
+                },
             },
             // Error model
             Error: {

--- a/src/routes/driver.ts
+++ b/src/routes/driver.ts
@@ -3,7 +3,9 @@ import {
     getDriversHandler,
     getOneDriverHandler,
     getDriversByYearHandler,
-    getSumPtsAllDriversHandler
+    getSumPtsAllDriversHandler,
+    searchDriversByNameHandler,
+    getYearlyRankingOfDriverHandler
 } from "../controllers/driver"
 
 const router = Router()
@@ -13,6 +15,8 @@ router.get("/", getDriversHandler)
 router.get("/year/:year", getDriversByYearHandler)
 router.get("/year/:year/points", getSumPtsAllDriversHandler)
 router.get("/:id", getOneDriverHandler)
+router.post("/search", searchDriversByNameHandler)
+router.get("/:id/yearly-ranking", getYearlyRankingOfDriverHandler)
 
 /**
  * 

--- a/src/test/test_driver.ts
+++ b/src/test/test_driver.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import requestInstance from './client';
-import { Participation } from '../models/participation';
+import FormData from 'form-data';
 
 describe('Driver API', () => {
     describe('GET /drivers', () => {
@@ -16,7 +16,7 @@ describe('Driver API', () => {
             assert.isArray(response.data.list);
             assert.isAbove(response.data.list.length, 0);
             for (let i = 1; i < response.data.list.length; i++) {
-              assert.ok(response.data.list[i].firstname >= response.data.list[i - 1].firstname, 'Driver list is not in firstname order');
+                assert.ok(response.data.list[i].firstname >= response.data.list[i - 1].firstname, 'Driver list is not in firstname order');
             }
         });
         it('should return driver list in lastname order when sort is not firstname', async () => {
@@ -25,7 +25,7 @@ describe('Driver API', () => {
             assert.isArray(response.data.list);
             assert.isAbove(response.data.list.length, 0);
             for (let i = 1; i < response.data.list.length; i++) {
-              assert.ok(response.data.list[i].lastname >= response.data.list[i - 1].lastname, 'Driver list are not in lastname order');
+                assert.ok(response.data.list[i].lastname >= response.data.list[i - 1].lastname, 'Driver list are not in lastname order');
             }
         });
     });
@@ -43,7 +43,7 @@ describe('Driver API', () => {
                 const nonExistentId = '64a0347faa416f5926961dd3'; // Replace with a non-existent driver id
                 await requestInstance.get(`/drivers/${nonExistentId}`);
             }
-            catch(err:any) {
+            catch (err: any) {
                 assert.strictEqual(err.response.status, 404);
                 assert.strictEqual(err.response.data.message, 'driver not found');
                 return
@@ -64,7 +64,7 @@ describe('Driver API', () => {
         });
         it('should return 404 if driver of invalid year', async () => {
             try {
-                const response = await requestInstance.get(`/drivers/year/2012`);            
+                const response = await requestInstance.get(`/drivers/year/2012`);
             }
             catch (err: any) {
                 assert.strictEqual(err.response.status, 404);
@@ -80,7 +80,7 @@ describe('Driver API', () => {
             assert.isArray(response.data.list);
             assert.isAbove(response.data.list.length, 0);
             for (let i = 1; i < response.data.list.length; i++) {
-              assert.ok(response.data.list[i].firstname >= response.data.list[i - 1].firstname, 'Driver list is not in firstname order');
+                assert.ok(response.data.list[i].firstname >= response.data.list[i - 1].firstname, 'Driver list is not in firstname order');
             }
         });
         it('should return drivers in 1 year in lastname order when sort is not firstname', async () => {
@@ -90,7 +90,7 @@ describe('Driver API', () => {
             assert.isArray(response.data.list);
             assert.isAbove(response.data.list.length, 0);
             for (let i = 1; i < response.data.list.length; i++) {
-              assert.ok(response.data.list[i].lastname >= response.data.list[i - 1].lastname, 'Driver list are not in lastname order');
+                assert.ok(response.data.list[i].lastname >= response.data.list[i - 1].lastname, 'Driver list are not in lastname order');
             }
         });
     });
@@ -120,4 +120,114 @@ describe('Driver API', () => {
             throw `Should throw error but did not`
         });
     });
+
+    describe('POST /drivers/search', () => {
+        describe('when isLastName is true', () => {
+            it('returns the driver(s) with such lastname', async () => {
+                const inputData = { "driverName": "Hamilton", "isLastName": true }
+                const response = await requestInstance.post('/drivers/search', inputData, {
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                })
+                assert.strictEqual(response.status, 200);
+                assert.strictEqual(response.data.list[0].firstname, 'Lewis')
+                assert.strictEqual(response.data.list[0].lastname, 'Hamilton')
+            });
+        });
+
+
+        it('should return 404 if driverName is not available lastname', async () => {
+            try {
+                const inputData = { "driverName": "Lewis", "isLastName": true }
+                const response = await requestInstance.post('/drivers/search', inputData, {
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                })
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'cannot find driver with such name');
+                return
+            }
+            throw `Should throw error but did not`
+        });
+
+        it('should return 400 when there is no driverName', async () => {
+            try {
+                const inputData = { "isLastName": true }
+                const response = await requestInstance.post('/drivers/search', inputData, {
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                })
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 400)
+                assert.strictEqual(err.response.data.message, 'please provide driver name');
+                return
+            }
+            throw `Should throw error but did not`
+         
+        });
+
+    });
+
+    describe('when isLastName is false', () => {
+        it('returns the driver(s) with such firstname when driverName is correct', async () => {
+            const inputData = { "driverName": "Lewis", "isLastName": false }
+            const response = await requestInstance.post('/drivers/search', inputData, {
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            })
+            assert.strictEqual(response.status, 200);
+            assert.strictEqual(response.data.list[0].firstname, 'Lewis')
+            assert.strictEqual(response.data.list[0].lastname, 'Hamilton')
+        });
+
+        it('should return 404 if driverName is not available firstname', async () => {
+            try {
+                const inputData = { "driverName": "Hamilton", "isLastName": false }
+                const response = await requestInstance.post('/drivers/search', inputData, {
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                })
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'cannot find driver with such name');
+                return
+            }
+            throw `Should throw error but did not`
+        });
+    });
+
+    describe('GET /drivers/:id/yearly-ranking', () => {
+        it('should return list of yearly ranking of a driver', async () => {
+            const driverId = '64a0347faa416f5926961dd4';
+            const response = await requestInstance.get(`/drivers/${driverId}/yearly-ranking`);
+            assert.strictEqual(response.status, 200);
+            assert.strictEqual(response.data.target._id, driverId);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            assert.exists(response.data.list[0].rank)
+        });
+
+        it('should return 404 if driver not found', async () => {
+            try {
+                const nonExistentId = '64a0347faa416f5926961dd3'; // Replace with a non-existent driver id
+                await requestInstance.get(`/drivers/${nonExistentId}/yearly-ranking`);
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'driver not found');
+                return
+            }
+            throw `Should throw error but did not`
+        });
+    });
+
 });

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -50,8 +50,17 @@ export interface ITeamParti {
     driverInfos: driverContri[];
 }
 
+export interface IDriverYearlyRanking {
+    rank: number;	
+    team: string; 
+    sumPts: number;	
+    rankChanged: number;
+    year: number;
+}
+
 type validTarget = IGrandPrix | IDriver | ITeam | IParticipation
     | IWinner | ISumPts | IDriverParti | ITeamSumPts | ITeamParti
+    | IDriverYearlyRanking
 
 
 export interface resFormat {


### PR DESCRIPTION
## Done 
- Add route to allow search by driver 
   - `POST` request to allow user to search using driver name
        - allow find by firstname (default is lastname)
   - Yearly ranking of driver  
       - at each year also show sumpoints and compare to previous year's rank
- Add auto docs and unnittest for these routes

## Test results
![image](https://github.com/tten5/F1ResultsApp/assets/71060912/3e2bb860-7d6f-4ae1-9c2a-5c79255d2018)

