### PR TITLE
Add routes to search by team

### DIFF
--- a/src/docs/Teams/getYearlyRankingBestDriver.ts
+++ b/src/docs/Teams/getYearlyRankingBestDriver.ts
@@ -1,9 +1,9 @@
 export default {
     // method of operation
     get: {
-        tags: ["driver-operations"], 
-        description: "Get yearly ranking of a driver", 
-        operationId: "getYearlyRankingOfDriver", 
+        tags: ["team-operations"], 
+        description: "Get yearly best driver of a team", 
+        operationId: "getYearlyRankingOfTeam", 
         parameters: [
             {
                 name: "id", 
@@ -11,26 +11,26 @@ export default {
                 schema: {
                     type: "string"
                 },
-                description: "id of driver",
+                description: "id of team",
                 required: true
             },
         ], 
         // expected responses
         responses: {
             200: {
-                description: "Received yearly ranking of driver successfully", 
+                description: "Received yearly best driver of team successfully", 
                 content: {
                     // content-type
                     "application/json": {
                         schema: {
-                            $ref: '#/components/schemas/DriverYearlyRankingList', 
+                            $ref: '#/components/schemas/TeamYearlyBestDriverList', 
                         },
                     },
                 },
             },
             // response code
             404: {
-                description: "driver not found", // response desc.
+                description: "team not found", // response desc.
                 content: {
                     // content-type
                     "application/json": {

--- a/src/docs/Teams/getYearlyRankingOfTeam.ts
+++ b/src/docs/Teams/getYearlyRankingOfTeam.ts
@@ -1,9 +1,9 @@
 export default {
     // method of operation
     get: {
-        tags: ["driver-operations"], 
-        description: "Get yearly ranking of a driver", 
-        operationId: "getYearlyRankingOfDriver", 
+        tags: ["team-operations"], 
+        description: "Get yearly ranking of a team", 
+        operationId: "getYearlyRankingOfTeam", 
         parameters: [
             {
                 name: "id", 
@@ -11,26 +11,26 @@ export default {
                 schema: {
                     type: "string"
                 },
-                description: "id of driver",
+                description: "id of team",
                 required: true
             },
         ], 
         // expected responses
         responses: {
             200: {
-                description: "Received yearly ranking of driver successfully", 
+                description: "Received yearly ranking of team successfully", 
                 content: {
                     // content-type
                     "application/json": {
                         schema: {
-                            $ref: '#/components/schemas/DriverYearlyRankingList', 
+                            $ref: '#/components/schemas/TeamYearlyRankingList', 
                         },
                     },
                 },
             },
             // response code
             404: {
-                description: "driver not found", // response desc.
+                description: "team not found", // response desc.
                 content: {
                     // content-type
                     "application/json": {

--- a/src/docs/Teams/index.ts
+++ b/src/docs/Teams/index.ts
@@ -2,6 +2,8 @@ import getOneTeam from './getOneTeam';
 import getAllTeams from './getAllTeams';
 import getTeamsByYear from './getTeamsByYear'
 import getSumPtsAllTeams from './getSumPtsAllTeams';
+import getYearlyRankingOfTeam from './getYearlyRankingOfTeam';
+import getYearlyRankingBestDriver from './getYearlyRankingBestDriver';
 
 export default {
     '/api/v1/teams': {
@@ -15,5 +17,11 @@ export default {
     },
     '/api/v1/teams/{id}': {
         ...getOneTeam,
+    },
+    '/api/v1/teams/{id}/yearly-ranking': {
+        ...getYearlyRankingOfTeam,
+    },
+    '/api/v1/teams/{id}/yearly-best-driver': {
+        ...getYearlyRankingBestDriver,
     },
 }

--- a/src/docs/components.ts
+++ b/src/docs/components.ts
@@ -428,6 +428,55 @@ export default {
                     }
                 },
             },
+            // team yearly ranking
+            TeamYearlyRankingList: {
+                type: "array", // data type
+                description: "an array of yearly ranking of a team",
+                items: {
+                    "type": "object",
+                    "properties": {
+                        "rank": {
+                            $ref: '#/components/schemas/rank'
+                        },
+                        "sumPts": {
+                            $ref: '#/components/schemas/points'
+                        },
+                        "rankChanged": {
+                            $ref: '#/components/schemas/rank'
+                        },
+                        "year": {
+                            $ref: '#/components/schemas/year'
+                        }
+                    }
+                },
+            },
+            //
+            TeamYearlyBestDriverList: {
+                type: "array", // data type
+                description: "an array of yearly best driver of a team",
+                items: {
+
+                    "type": "object",
+                    "properties": {
+                        "year": {
+                            $ref: '#/components/schemas/year'
+                        },
+                        "driver": {
+                            $ref: '#/components/schemas/fullname'
+                        },
+                        "sumPts": {
+                            $ref: '#/components/schemas/points'
+                        },
+                        "teamTotalPts": {
+                            $ref: '#/components/schemas/poits'
+                        },
+                        "percentage": {
+                            $ref: '#/components/schemas/percentage'
+                        }
+                    }
+                }
+
+            },
             // Error model
             Error: {
                 type: "object", //data type

--- a/src/routes/team.ts
+++ b/src/routes/team.ts
@@ -3,7 +3,9 @@ import {
     getTeamsHandler,
     getOneTeamHandler,
     getTeamsByYearHandler,
-    getSumPtsAllTeamsHandler
+    getSumPtsAllTeamsHandler,
+    getYearlyRankingOfTeamHandler,
+    getYearlyBestDriverHandler
 } from "../controllers/team"
 
 const router = Router()
@@ -13,14 +15,12 @@ router.get("/", getTeamsHandler)
 router.get("/year/:year", getTeamsByYearHandler)
 router.get("/year/:year/points", getSumPtsAllTeamsHandler)
 router.get("/:id", getOneTeamHandler)
+router.get("/:id/yearly-ranking", getYearlyRankingOfTeamHandler)
+router.get("/:id/yearly-best-driver", getYearlyBestDriverHandler)
 
 /**
  * by year and driver and all -> get /year/:year/points
  * 
- * POST to search for driver with user input /search , 
- * 
- * yearly ranknig: /:id/yearly-ranking/ 
- * team's best driver over year /:id/yearly-best-driver
  * 
  * 
  * 

--- a/src/test/test_driver.ts
+++ b/src/test/test_driver.ts
@@ -214,6 +214,7 @@ describe('Driver API', () => {
             assert.isArray(response.data.list);
             assert.isAbove(response.data.list.length, 0);
             assert.exists(response.data.list[0].rank)
+            assert.isTrue(response.data.list[1].year > response.data.list[0].year)
         });
 
         it('should return 404 if driver not found', async () => {
@@ -229,5 +230,4 @@ describe('Driver API', () => {
             throw `Should throw error but did not`
         });
     });
-
 });

--- a/src/test/test_team.ts
+++ b/src/test/test_team.ts
@@ -83,5 +83,61 @@ describe('Team API', () => {
             }
             throw `Should throw error but did not`
         });
+
+   
+
+        
+    });
+
+    describe('GET /teams/:id/yearly-ranking', () => {
+        it('should return list of yearly ranking of a team', async () => {
+            const teamId = '649d42fb8f9d812c3201f569';
+            const response = await requestInstance.get(`/teams/${teamId}/yearly-ranking`);
+            assert.strictEqual(response.status, 200);
+            assert.strictEqual(response.data.target._id, teamId);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            assert.exists(response.data.list[0].rank)
+            assert.isTrue(response.data.list[1].year > response.data.list[0].year)
+        });
+
+        it('should return 404 if team not found', async () => {
+            try {
+                const nonExistentId = '64a0347faa416f5926961dd3'; // Replace with a non-existent team id
+                await requestInstance.get(`/teams/${nonExistentId}/yearly-ranking`);
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'team not found');
+                return
+            }
+            throw `Should throw error but did not`
+        });
+    });
+
+    describe('GET /teams/:id/yearly-best-driver', () => {
+        it('should return list of yearly best-driver of a team', async () => {
+            const teamId = '649d42fb8f9d812c3201f569';
+            const response = await requestInstance.get(`/teams/${teamId}/yearly-best-driver`);
+            assert.strictEqual(response.status, 200);
+            assert.strictEqual(response.data.target._id, teamId);
+            assert.isArray(response.data.list);
+            assert.isAbove(response.data.list.length, 0);
+            assert.exists(response.data.list[0].driver)
+            assert.isTrue(response.data.list[1].year > response.data.list[0].year)
+        });
+
+        it('should return 404 if team not found', async () => {
+            try {
+                const nonExistentId = '64a0347faa416f5926961dd3'; // Replace with a non-existent team id
+                await requestInstance.get(`/teams/${nonExistentId}/yearly-best-driver`);
+            }
+            catch (err: any) {
+                assert.strictEqual(err.response.status, 404);
+                assert.strictEqual(err.response.data.message, 'team not found');
+                return
+            }
+            throw `Should throw error but did not`
+        });
     });
 });

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -50,17 +50,28 @@ export interface ITeamParti {
     driverInfos: driverContri[];
 }
 
-export interface IDriverYearlyRanking {
+export interface IYearlyRanking {
     rank: number;	
-    team: string; 
     sumPts: number;	
     rankChanged: number;
     year: number;
 }
 
+export interface IDriverYearlyRanking extends IYearlyRanking {
+    team: string; 
+}
+
+export interface ITeamYearlyBestDriver { 
+    year: number;
+    driver: string;
+    sumPts: number;
+    teamTotalPts: number;
+    percentage: string;
+}
+
 type validTarget = IGrandPrix | IDriver | ITeam | IParticipation
     | IWinner | ISumPts | IDriverParti | ITeamSumPts | ITeamParti
-    | IDriverYearlyRanking
+    | IDriverYearlyRanking | IYearlyRanking | ITeamYearlyBestDriver
 
 
 export interface resFormat {


### PR DESCRIPTION
## Done
- Add routes to search by team (use team_id)
    - Yearly ranking of team: at each year also show sumpoints and compare to prev year rank 
    - Team's best driver over year: show driver name, percentage of the sum points driver has contributed to team's total points
 - Add auto doc and unittest for these routes
## Test result
![image](https://github.com/tten5/F1ResultsApp/assets/71060912/e4bf6c97-82c5-4146-b46c-751311f2658e)
